### PR TITLE
Log Empty Searches

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -247,11 +247,6 @@ app.get('/search', wrap(async (req, res) => {
 
   macros.logAmplitudeEvent('Backend Search', analytics);
 
-  if (resultCount === 0 && req.query.minIndex === 0) {
-    macros.logAmplitudeEvent('Backend No Search Results', analytics);
-  }
-
-
   macros.log(getTime(), getIpPath(req), 'Search for', req.query.query, 'from', minIndex, 'to', maxIndex, 'took', took, 'ms and stringify took', Date.now() - midTime, 'with', analytics.resultCount, 'results');
 
   // Set the header for application/json and send the data.

--- a/backend/server.js
+++ b/backend/server.js
@@ -247,6 +247,11 @@ app.get('/search', wrap(async (req, res) => {
 
   macros.logAmplitudeEvent('Backend Search', analytics);
 
+  if (resultCount === 0 && req.query.minIndex === 0) {
+    macros.logAmplitudeEvent('Backend No Search Results', analytics);
+  }
+
+
   macros.log(getTime(), getIpPath(req), 'Search for', req.query.query, 'from', minIndex, 'to', maxIndex, 'took', took, 'ms and stringify took', Date.now() - midTime, 'with', analytics.resultCount, 'results');
 
   // Set the header for application/json and send the data.

--- a/frontend/components/Home.js
+++ b/frontend/components/Home.js
@@ -393,6 +393,10 @@ class Home extends React.Component {
       newState.results = results;
       newState.subjectName = obj.subjectName;
       newState.subjectCount = obj.subjectCount;
+
+      if (results.length === 0) {
+        macros.logAmplitudeEvent('Frontend Search No Results', { query: searchQuery.toLowerCase(), sessionCount: this.searchCount });
+      }
     }
 
 
@@ -461,7 +465,6 @@ class Home extends React.Component {
           </div>
         );
       } else if (this.state.results.length === 0 && this.state.searchQuery.length > 0 && !this.state.waitingOnEnter) {
-        macros.logAmplitudeEvent('Frontend Search No Results', { query: searchQuery.toLowerCase(), sessionCount: this.searchCount });
         resultsElement = (
           <div className='noResultsContainer'>
             <h3>

--- a/frontend/components/Home.js
+++ b/frontend/components/Home.js
@@ -461,6 +461,7 @@ class Home extends React.Component {
           </div>
         );
       } else if (this.state.results.length === 0 && this.state.searchQuery.length > 0 && !this.state.waitingOnEnter) {
+        macros.logAmplitudeEvent('Frontend Search No Results', { query: searchQuery.toLowerCase(), sessionCount: this.searchCount });
         resultsElement = (
           <div className='noResultsContainer'>
             <h3>


### PR DESCRIPTION
Add logging back to searches, only do it on initial query.

Edit: I'm thinking that it makes more sense to stop logging the event on the backend entirely and focus on logging how frequently the user sees `No Results`, because I think that's what we ought to be tracking regarding the user experience. 