### PR TITLE
Correct hover on Course Attributes

### DIFF
--- a/frontend/css/panels/_DesktopClassPanel.scss
+++ b/frontend/css/panels/_DesktopClassPanel.scss
@@ -53,4 +53,8 @@
 
 .Collapsible__trigger {
   color: #009fda;
+  cursor: pointer;
+  &:hover {
+    color: #1e70bf;
+  }
 }


### PR DESCRIPTION
Thought I'd do a quick fix while I had the chance.

Right now, when you hover on Course Attributes, you get the `text` cursor and no darkening, like the other links on the result. Adding some CSS so that it conforms to the same pattern.