### PR TITLE
Add dotenv

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 
 module.exports = {
   dev: {
@@ -15,6 +16,10 @@ module.exports = {
     dialect: 'postgres',
   },
   prod: {
+    username: process.env.dbUsername,
+    password: process.env.dbPassword,
+    database: process.env.dbName,
+    host: process.env.dbHost,
     dialect: 'postgres',
   },
 };

--- a/models/index.js
+++ b/models/index.js
@@ -9,13 +9,6 @@ const env = process.env.NODE_ENV || 'dev';
 const config = require(__dirname + '/../config/config.js')[env];
 const db = {};
 
-if (env === 'prod') {
-  config.username = macros.getEnvVariable('dbUsername');
-  config.password = macros.getEnvVariable('dbPassword');
-  config.database = macros.getEnvVariable('dbName');
-  config.host = macros.getEnvVariable('dbHost');
-}
-
 let sequelize;
 if (config.use_env_variable) {
   sequelize = new Sequelize(process.env[config.use_env_variable], config);

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "cross-env": "^5.0.0",
     "dnscache": "^1.0.1",
     "domutils": "^1.6.2",
+    "dotenv": "^8.2.0",
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.1.0",
     "enzyme-to-json": "^3.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4151,6 +4151,11 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 dottie@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/dottie/-/dottie-2.0.1.tgz#697ad9d72004db7574d21f892466a3c285893659"


### PR DESCRIPTION
Two reasons for this:
1. Sequelize can't import our own modules, so `macros` doesn't work (but `dotenv` does)
2. Would be good to start moving to env variables as it is 