### PR TITLE
Fix DB migration on Prod

### DIFF
--- a/travis_deploy.sh
+++ b/travis_deploy.sh
@@ -108,7 +108,7 @@ if [ "$TRAVIS_BRANCH" == "prod" ]; then
   if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
     # If this is a cron job, we need to take down the server while the re-index is running so users's don't get invalid or incomplete data.
     # Taking down the server isn't idea, but its better than caches (both on our side and the user's side) getting invalid or incomplete data.
-    ssh -o StrictHostKeyChecking=no ubuntu@3.214.162.230 'cd searchneu; npm run stop_prod; yarn; npm run store; npm run index; npm run start_prod'
+    ssh -o StrictHostKeyChecking=no ubuntu@3.214.162.230 'cd searchneu; npm run stop_prod; yarn; NODE_ENV=prod npm run store; npm run index; npm run start_prod'
   else
     # If this is not a cron job, we don't have to take down the server for a few seconds.
     # Install any new packages while it is running, and then reboot the server.


### PR DESCRIPTION
`yarn store` was not running in prod mode on production, so it just blew up. 