### PR TITLE
Scrapers stop using all the ram

### DIFF
--- a/backend/scrapers/classes/parsersxe/bannerv9Parser.js
+++ b/backend/scrapers/classes/parsersxe/bannerv9Parser.js
@@ -28,7 +28,7 @@ class Bannerv9Parser {
      */
     const termsToKeep = bannerTerms.body;
 
-    const terms = ['201930'];//, '201940', '201950', '201960', '202010'];
+    const terms = ['202030'];//, '201940', '201950', '201960', '202010'];
 
     const serializedTerms = this.serializeTermsList(termsToKeep).filter((t) => { return terms.includes(t.termId); });
 

--- a/backend/scrapers/classes/parsersxe/bannerv9Parser.js
+++ b/backend/scrapers/classes/parsersxe/bannerv9Parser.js
@@ -4,11 +4,13 @@
  */
 
 
+import _ from 'lodash';
 import cache from '../../cache';
 import macros from '../../../macros';
 import Request from '../../request';
 import SearchResultsParser from './searchResultsParser';
 import Keys from '../../../../common/Keys';
+import util from './util';
 
 const request = new Request('bannerv9Parser');
 
@@ -24,9 +26,13 @@ class Bannerv9Parser {
      * memory than default allocation by node.js
      * performance: 60-90 seconds per term
      */
-    const termsToKeep = bannerTerms.body.slice(0, 3);
+    const termsToKeep = bannerTerms.body;
 
-    const serializedTerms = this.serializeTermsList(termsToKeep);
+    const terms = ['201930'];//, '201940', '201950', '201960', '202010'];
+
+    const serializedTerms = this.serializeTermsList(termsToKeep).filter((t) => { return terms.includes(t.termId); });
+
+    macros.log('scraping terms', serializedTerms.map((t) => { return t.termId; }));
 
     let subjectsRequests = [];
     let sectionsDataPerEveryTerm = [];
@@ -43,15 +49,12 @@ class Bannerv9Parser {
       allSubjects = allSubjects.concat(this.processSubjectListResponse(subjectResponse, term));
     });
 
-    const detailsRequests = [];
-    sectionsDataPerEveryTerm.forEach((allSectionsFromTerm) => {
-      allSectionsFromTerm.forEach((searchResultsFromXE) => {
-        // searchResultsFromXE is JSON object from here
-        // https://jennydaman.gitlab.io/nubanned/dark.html#studentregistrationssb-search-get
-        detailsRequests.push(SearchResultsParser.mostDetails(searchResultsFromXE));
-      });
-    });
-    const allSections = await Promise.all(detailsRequests);
+    const allSectionsEveryTerm = _.flatten(sectionsDataPerEveryTerm);
+    macros.log(`scraping ${allSectionsEveryTerm.length} sections`);
+    const allSections = await util.promiseMap(allSectionsEveryTerm,
+      (x) => { return SearchResultsParser.mostDetails(x); },
+      { concurrency: 300 });
+    macros.log('all sections scraped');
 
     // TOD: Run any other parsers you want to run
     // All of the other existing parsers run 0 or 1 other parsers, but you can run any number

--- a/backend/scrapers/classes/parsersxe/util.js
+++ b/backend/scrapers/classes/parsersxe/util.js
@@ -67,6 +67,36 @@ function parseTable(table) {
   return ret;
 }
 
+function promiseMap(iterable, mapper, options) {
+  options = options || {};
+  let concurrency = options.concurrency || Infinity;
+
+  let index = 0;
+  const results = [];
+  const iterator = iterable[Symbol.iterator]();
+  const promises = [];
+
+  while (concurrency-- > 0) {
+    const promise = wrappedMapper();
+    if (promise) promises.push(promise);
+    else break;
+  }
+
+  return Promise.all(promises).then(() => { return results; });
+
+  function wrappedMapper() {
+    const next = iterator.next();
+    if (next.done) return null;
+    const i = index++;
+    const mapped = mapper(next.value, i);
+    return Promise.resolve(mapped).then((resolved) => {
+      results[i] = resolved;
+      return wrappedMapper();
+    });
+  }
+}
+
 export default {
   parseTable: parseTable,
+  promiseMap: promiseMap,
 };


### PR DESCRIPTION
Promisemap is like promise.all but resolves in sequentially instead of concurrently. can also give it a concurrency limit to batch them. make ram usage during promise resolution more or less constant instead of linear because we cap concurrency.