### PR TITLE
Log classes missing CRNs in the updater

### DIFF
--- a/backend/updater.js
+++ b/backend/updater.js
@@ -284,7 +284,13 @@ class Updater {
 
     const classMap = {};
     for (const aClass of output.classes) {
-      const associatedSections = output.sections.filter((s) => { return aClass.crns.includes(s.crn); });
+      const associatedSections = output.sections.filter((s) => {
+        if (!aClass.crns) {
+          macros.log(`The class ${aClass.subject} ${aClass.classId} in ${aClass.termId} does not have crns!`);
+          return false;
+        }
+        return aClass.crns.includes(s.crn);
+      });
       // Sort each classes section by crn.
       // This will keep the sections the same between different scrapings.
       if (associatedSections.length > 1) {


### PR DESCRIPTION
It's unclear at the moment why classes have a null value rather than an empty array for CRNs: the scrapers, as far as I can tell, make sure to create an empty array for the field. However, this issue is crashing the site. Without a very good test suite built out for the updater and tracking this stuff being somewhat difficult otherwise, I just want to log it when it happens (and stop crashing). 

Sidenote: not logging in Rollbar because we already ran out of our monthly rollbar errors. 