### PR TITLE
3 Fixes

### DIFF
--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -273,7 +273,14 @@ class Elastic {
             filter: {
               bool: {
                 should: [
-                  { term: { 'class.termId': termId } },
+                  {
+                    bool:{
+                      must: [
+                        { exists: { field: 'sections' } },
+                        { term: { 'class.termId': termId } },
+                      ],
+                    },
+                  },
                   { term: { type: 'employee' } },
                 ],
               },

--- a/backend/scrapers/classes/parsersxe/bannerv9Parser.js
+++ b/backend/scrapers/classes/parsersxe/bannerv9Parser.js
@@ -56,8 +56,8 @@ class Bannerv9Parser {
    */
   async scrapeClass(termId, subject, courseNumber) {
     return {
-      classes: ClassParser.parseClass(termId, subject, courseNumber),
-      sections: SectionParser.parseSectionsOfClass(termId, subject, courseNumber),
+      classes: [await ClassParser.parseClass(termId, subject, courseNumber)],
+      sections: await SectionParser.parseSectionsOfClass(termId, subject, courseNumber),
     };
   }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -22,7 +22,7 @@ import Request from './scrapers/request';
 import webpackConfig from './webpack.config.babel';
 import macros from './macros';
 import notifyer from './notifyer';
-// import Updater from './updater';
+import Updater from './updater';
 import database from './database';
 import graphql from './graphql';
 import requestMapping from './requestMapping.json';
@@ -56,7 +56,7 @@ const MAX_HOLD_TIME_FOR_GET_USER_DATA_REQS = 3000;
 let getUserDataInterval = null;
 
 // Start updater interval
-// Updater.create();
+Updater.create();
 
 // Verify that the webhooks are coming from facebook
 // This needs to be above bodyParser for some reason

--- a/backend/server.js
+++ b/backend/server.js
@@ -135,7 +135,7 @@ function getRemoteIp(req) {
   }
 
   if (macros.PROD) {
-    macros.warn('No cf-connecting-ip?', req.headers, req.connection.remoteAddress);
+    // macros.warn('No cf-connecting-ip?', req.headers, req.connection.remoteAddress);
     return '';
   }
 

--- a/backend/updater.js
+++ b/backend/updater.js
@@ -4,7 +4,6 @@
  */
 
 import _ from 'lodash';
-import pMap from 'p-map';
 
 import elastic from './elastic';
 

--- a/backend/updater.js
+++ b/backend/updater.js
@@ -19,7 +19,7 @@ class Updater {
   constructor() {
     // 5 min if prod, 30 sec if dev.
     // In dev the cache will be used so we are not actually hitting NEU's servers anyway.
-    const intervalTime = macros.PROD ? 300000 : 10000;
+    const intervalTime = macros.PROD ? 300000 : 30000;
 
     setInterval(() => {
       try {
@@ -177,7 +177,6 @@ class Updater {
       // Count how many sections are present in the new but not in the old.
       let count = 0;
       if (aNewClass.sections) {
-        macros.log(oldClass);
         const newCrns = aNewClass.sections.map((section) => { return section.crn; });
         const oldCrns = oldClass.sections.map((section) => { return section.crn; });
 

--- a/backend/updater.js
+++ b/backend/updater.js
@@ -4,15 +4,14 @@
  */
 
 import _ from 'lodash';
+import pMap from 'p-map';
 
 import elastic from './elastic';
 
-import classesScrapers from './scrapers/classes/main';
-
+import Bannerv9Parser from './scrapers/classes/parsersxe/bannerv9Parser';
 import macros from './macros';
 import database from './database';
 import Keys from '../common/Keys';
-import ellucianCatalogParser from './scrapers/classes/parsers/ellucianCatalogParser';
 import notifyer from './notifyer';
 
 
@@ -21,7 +20,7 @@ class Updater {
   constructor() {
     // 5 min if prod, 30 sec if dev.
     // In dev the cache will be used so we are not actually hitting NEU's servers anyway.
-    const intervalTime = macros.PROD ? 300000 : 30000;
+    const intervalTime = macros.PROD ? 300000 : 10000;
 
     setInterval(() => {
       try {
@@ -30,6 +29,7 @@ class Updater {
         macros.warn('Updater failed with :', e);
       }
     }, intervalTime);
+    this.onInterval();
   }
 
 
@@ -121,7 +121,7 @@ class Updater {
     // Get the old data for watched classes
     const esOldDocs = await elastic.getMapFromIDs(elastic.CLASS_INDEX, classHashes);
 
-    const oldWatchedClasses = _.mapValues(esOldDocs, (doc) => { return doc.class; });
+    const oldWatchedClasses = _.mapValues(esOldDocs, (doc) => { return { sections: doc.sections, ...doc.class }; });
     const oldWatchedSections = {};
     for (const aClass of Object.values(esOldDocs)) {
       for (const section of aClass.sections) {
@@ -138,59 +138,33 @@ class Updater {
     }
 
     // Scrape the latest data
-    const promises = Object.values(oldWatchedClasses).map((aClass) => {
-      return ellucianCatalogParser.main(aClass.prettyUrl).then((newClass) => {
-        if (!newClass) {
-          // TODO: This should be changed into a notification that the class probably no longer exists. Shoudn't unsubscribe people.
-          macros.warn('New class data is null?', aClass.prettyUrl, aClass);
-          return null;
-        }
-
-
-        // Copy over some fields that are not scraped from this scraper.
-        newClass.value.host = aClass.host;
-        newClass.value.termId = aClass.termId;
-        newClass.value.subject = aClass.subject;
-
-        return newClass;
-      });
+    const promises = Object.values(oldWatchedClasses).map(async (aClass) => {
+      const promise = await Bannerv9Parser.scrapeClass(aClass.termId, aClass.subject, aClass.classId);
+      const { classes, sections } = promise;
+      if (classes.length === 1) {
+        classes[0].sections = sections;
+        return { classes: classes, sections: sections };
+      }
+      return null;
     });
 
-    // Remove the instances where newClass was null
-    _.pull(promises, null);
 
-    let allParsersOutput;
+    let output;
 
     try {
-      allParsersOutput = await Promise.all(promises);
+      output = await Promise.all(promises);
     } catch (e) {
-      macros.warn('ellucianCatalogParser call failed in updater with error:', e);
+      macros.warn('bannerv9parser call failed in updater with error:', e);
       return;
     }
 
     // Remove any instances where the output was null.
     // This can happen if the class at one of the urls that someone was watching dissapeared or was taken down
     // In this case the output of the ellucianCatalogParser will be null.
-    _.pull(allParsersOutput, null);
+    _.pull(output, null);
 
-    const rootNode = {
-      type: 'ignore',
-      deps: allParsersOutput,
-      value: {},
-    };
-
-    // Because ellucianCatalogParser returns a list of classes, instead of a singular class, we need to run it on all of them
-    const output = classesScrapers.restructureData(rootNode);
-
-    if (!output.sections) {
-      output.sections = [];
-    }
-
-    if (!output.classes) {
-      output.classes = [];
-    }
-
-    classesScrapers.runProcessors(output);
+    // concat classes and section arrays
+    output = _.mergeWith(...output, (a, b) => { return a.concat(b); });
 
     // Keep track of which messages to send which users.
     // The key is the facebookMessengerId and the value is a list of messages.
@@ -204,6 +178,7 @@ class Updater {
       // Count how many sections are present in the new but not in the old.
       let count = 0;
       if (aNewClass.sections) {
+        macros.log(oldClass);
         const newCrns = aNewClass.sections.map((section) => { return section.crn; });
         const oldCrns = oldClass.sections.map((section) => { return section.crn; });
 


### PR DESCRIPTION
1. Turn off the cf-connecting warning
2. Updater use v9
3. Only show classes that have sections


Do not merge unless scrapers have run recently. Don't want the updater to spam people when we merge!