### PR TITLE
Filters be es

### DIFF
--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -403,16 +403,86 @@ class Elastic {
                 ],
               },
             },
-            should: [
-              { term: { 'class.subject': 'EECE' } },
-            ],
           },
         },
       },
     };
 
-    macros.log(JSON.stringify(originalQuery));
-    const searchOutput = await client.search(originalQuery);
+    const prevQuery = {
+      index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
+      from: min,
+      size: max - min,
+      body: {
+        sort: [
+          '_score',
+          { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
+        ],
+        query: {
+          bool: {
+            must: {
+              multi_match: {
+                query: query,
+                type: 'most_fields', // More fields match => higher score
+                fuzziness: 'AUTO',
+                fields: fields,
+              },
+            },
+            filter: {
+              bool: {
+                should: [
+                  {
+                    bool:{
+                      must: [
+                        { exists: { field: 'sections' } },
+                        { term: { 'class.termId': termId } },
+                      ],
+                    },
+                  },
+                  { term: { type: 'employee' } },
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+
+
+    const testQuery = {
+      index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
+      from: 0,
+      size: 1000,
+      body: {
+        query: {
+          constant_score: {
+            filter: {
+              bool: {
+                must: [
+                  // {
+                  //   match: {
+                  //     'sections.online': true,
+                  //   },
+                  // },
+                  {
+                    match_phrase: {
+                      'class.scheduleType': 'Lab',
+                    },
+                  },
+                  // {
+                  //   match_phrase: {
+                  //     'class.classAttributes': 'GSEN Engineering',
+                  //   },
+                  // },
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    macros.log(JSON.stringify(testQuery));
+    const searchOutput = await client.search(testQuery);
 
     return {
       searchContent: searchOutput.body.hits.hits.map((hit) => { return { ...hit._source, score: hit._score }; }),
@@ -424,3 +494,18 @@ class Elastic {
 
 const instance = new Elastic();
 export default instance;
+
+/*
+
+
+curl -X GET "localhost:9200/classes/_search?pretty" -H 'Content-Type: application/json' -d'
+{
+  "query": {
+    "match": {
+      "sections.online": true
+    }
+  }
+}
+'
+
+*/

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -234,7 +234,7 @@ class Elastic {
    */
   validateFilters(filters) {
     const isString = (givenVar) => {
-      return typeof givenVar === 'string' || givenVar instanceof String;
+      return typeof givenVar === 'string';
     };
 
     const isStringArray = (givenVar) => {

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -14,6 +14,66 @@ const client = new Client({ node: URL });
 
 const BULKSIZE = 5000;
 
+/**
+   * Get elasticsearch query from json filters and termId
+   * @param  {string}  termId  The termId to look within
+   * @param  {object}  filters The json object representing all filters
+   */
+function getClassFilterQuery(termId, filters) {
+  // filter classes to get those with sections
+  const hasSections = { exists: { field: 'sections' } };
+
+  // filter by term
+  const filterByTermId = { term: { 'class.termId': termId } };
+
+  const getNUpathFilter = (selectedNUpaths) => {
+    const NUpathFilters = selectedNUpaths.map(eachNUpath => ({ match_phrase: { 'class.classAttributes': eachNUpath } }));
+    return { bool: { should: NUpathFilters } };
+  };
+
+  const getCollegeFilter = (selectedColleges) => {
+    const collegeFilters = selectedColleges.map(eachCollege => ({ match_phrase: { 'class.classAttributes': eachCollege } }));
+    return { bool: { should: collegeFilters } };
+  };
+
+  const getSubjectFilter = (selectedSubject) => {
+    const subjectFilters = selectedSubject.map(eachSubject => ({ match: { 'class.subject': eachSubject } }));
+    return { bool: { should: subjectFilters } };
+  };
+
+  // note that { online: false } should not never be in filters
+  const getOnlineFilter = (selectedOnlineOption) => {
+    return { term: { 'sections.online': selectedOnlineOption } };
+  };
+
+  const getClassTypeFilter = (selectedClassType) => {
+    return { match: { 'class.scheduleType': selectedClassType } };
+  };
+
+  // construct compound class filters (fliters joined by AND (must), options for a filter joined by OR (should))
+  const filterToEsQuery = {
+    NUpath: getNUpathFilter,
+    college: getCollegeFilter,
+    subject: getSubjectFilter,
+    online: getOnlineFilter,
+    classType: getClassTypeFilter,
+  };
+
+  const classFilters = [hasSections, filterByTermId];
+  for (const [filterKey, filterValues] of Object.entries(filters)) {
+    if (filterKey in filterToEsQuery) {
+      macros.log(`Filter: {${filterKey}: ${filterValues}}`);
+      macros.log(`Type: ${typeof filterToEsQuery[filterKey]}`);
+      macros.log(`Type: ${typeof filterToEsQuery.filterKey}`);
+      classFilters.push(filterToEsQuery[filterKey](filterValues));
+    } else {
+      macros.log(`Invalid filter: {${filterKey}: ${filterValues}}`);
+    }
+  }
+
+  return classFilters;
+}
+
 class Elastic {
   constructor() {
     // Because we export an instance of this class, put the constants on the instance.
@@ -251,56 +311,8 @@ class Elastic {
       fields = ['class.subject^10', 'class.classId'];
     }
 
-    // filter classes to get those with sections
-    const hasSections = { exists: { field: 'sections' } };
-
-    // filter by term
-    const filterByTermId = { term: { 'class.termId': termId } };
-
-    const getNUpathFilter = (selectedNUpaths) => {
-      const NUpathFilters = selectedNUpaths.map(eachNUpath => ({ match_phrase: { 'class.classAttributes': eachNUpath } }));
-      return { bool: { should: NUpathFilters } };
-    };
-
-    const getCollegeFilter = (selectedColleges) => {
-      const collegeFilters = selectedColleges.map(eachCollege => ({ match_phrase: { 'class.classAttributes': eachCollege } }));
-      return { bool: { should: collegeFilters } };
-    };
-
-    const getSubjectFilter = (selectedSubject) => {
-      const subjectFilters = selectedSubject.map(eachSubject => ({ match: { 'class.subject': eachSubject } }));
-      return { bool: { should: subjectFilters } };
-    };
-
-    // note that { online: false } should not never be in filters
-    const getOnlineFilter = (selectedOnlineOption) => {
-      return { term: { 'sections.online': selectedOnlineOption } };
-    };
-
-    const getClassTypeFilter = (selectedClassType) => {
-      return { match: { 'class.scheduleType': selectedClassType } };
-    };
-
-    // construct compound class filters (fliters joined by AND (must), options for a filter joined by OR (should))
-    const filterToEsQuery = {
-      NUpath: getNUpathFilter,
-      college: getCollegeFilter,
-      subject: getSubjectFilter,
-      online: getOnlineFilter,
-      classType: getClassTypeFilter,
-    };
-
-    const classFilters = [hasSections, filterByTermId];
-    for (const [filterKey, filterValues] of Object.entries(filters)) {
-      if (filterKey in filterToEsQuery) {
-        macros.log(`Filter: {${filterKey}: ${filterValues}}`);
-        macros.log(`Type: ${typeof filterToEsQuery[filterKey]}`);
-        macros.log(`Type: ${typeof filterToEsQuery.filterKey}`);
-        classFilters.push(filterToEsQuery[filterKey](filterValues));
-      } else {
-        macros.log(`Invalid filter: {${filterKey}: ${filterValues}}`);
-      }
-    }
+    // get compound class filters
+    const classFilters = getClassFilterQuery(termId, filters);
 
     // text query from the main search box
     const matchTextQuery = {

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -231,17 +231,17 @@ class Elastic {
     const filterByTermId = { term: { 'class.termId': termId } };
 
     const getNUpathFilter = (selectedNUpaths) => {
-      const NUpathFilters = selectedNUpaths.map(eachNUpath => ({ match_phrase: { 'class.classAttributes': eachNUpath } }));
+      const NUpathFilters = selectedNUpaths.map((eachNUpath) => ({ match_phrase: { 'class.classAttributes': eachNUpath } }));
       return { bool: { should: NUpathFilters } };
     };
 
     const getCollegeFilter = (selectedColleges) => {
-      const collegeFilters = selectedColleges.map(eachCollege => ({ match_phrase: { 'class.classAttributes': eachCollege } }));
+      const collegeFilters = selectedColleges.map((eachCollege) => ({ match_phrase: { 'class.classAttributes': eachCollege } }));
       return { bool: { should: collegeFilters } };
     };
 
     const getSubjectFilter = (selectedSubject) => {
-      const subjectFilters = selectedSubject.map(eachSubject => ({ match: { 'class.subject': eachSubject } }));
+      const subjectFilters = selectedSubject.map((eachSubject) => ({ match: { 'class.subject': eachSubject } }));
       return { bool: { should: subjectFilters } };
     };
 

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -258,27 +258,24 @@ class Elastic {
     const filterByTermId = { term: { 'class.termId': termId } };
 
     // Constuct compound class filters
-    let classFilters = [hasSections, filterByTermId];
-    if (filters) {
-      for (const [filterKey, filterValues] of Object.entries(filters)) {
-        switch (filterKey) {
-          case 'NUpath':
-            break;
-          case 'college':
-            break;
-          case 'subject':
-            break;
-          case 'online':
-            break;
-          case 'sectionAvailable':
-            break;
-          case 'classType':
-            break;
-          default:
-            macros.log(`Filter error: Invalid filter {${filterKey}: ${filterValues}}`);
-            break;
-        }
-      }
+    const classFilters = [hasSections, filterByTermId];
+    if ('NUpath' in filters) {
+      const NUpathFilters = filters.NUpath.map(attribute => ({ match_phrase: { 'class.classAttributes': attribute } }));
+      classFilters.push({ bool: { should: NUpathFilters } });
+    }
+    if ('college' in filters) {
+      const collegeFilters = filters.college.map(attribute => ({ match_phrase: { 'class.classAttributes': attribute } }));
+      classFilters.push({ bool: { should: collegeFilters } });
+    }
+    if ('subject' in filters) {
+      const subjectFilters = filters.subject.map(eachSubject => ({ match: { 'class.subject': eachSubject } }));
+      classFilters.push(subjectFilters);
+    }
+    if ('online' in filters && filters.online) {
+      classFilters.push({ term: { 'sections.online': true } });
+    }
+    if ('classType' in filters) {
+      classFilters.push({ term: { 'sections.online': filters.classType } });
     }
 
     // Text query from the main search box
@@ -307,11 +304,64 @@ class Elastic {
         query: {
           bool: {
             must: matchTextQuery,
-            filter: { bool: { should: [{ bool:{ must: classFilters } }, isEmployee] } },
+            filter: {
+              bool: {
+                should: [
+                  { bool:{ must: classFilters } },
+                  isEmployee,
+                ],
+              },
+            },
           },
         },
       },
     };
+
+    const texst = {
+      index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
+      from: min,
+      size: max - min,
+      body: {
+        sort: [
+          '_score',
+          { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
+        ],
+        query: {
+          bool: {
+            must: {
+              multi_match: {
+                query: query,
+                type: 'most_fields', // More fields match => higher score
+                fuzziness: 'AUTO',
+                fields: fields,
+              },
+            },
+            filter: {
+              bool: {
+                should: [
+                  {
+                    bool: {
+                      must: [
+                        { exists: { field: 'sections' } },
+                        { term: { 'class.termId': termId } },
+                        {
+                          bool: {
+                            should: [
+                              { match_phrase: { 'class.classAttributes': termId } },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  { term: { type: 'employee' } },
+                ],
+              },
+            },
+          },
+        },
+      },
+    }
 
     macros.log(JSON.stringify(mainQuery));
     const searchOutput = await client.search(mainQuery);

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -251,107 +251,37 @@ class Elastic {
       fields = ['class.subject^10', 'class.classId'];
     }
 
+    // Filter classes to get those with sections
+    const hasSections = { exists: { field: 'sections' } };
+
+    // Filter by term
+    const filterByTermId = { term: { 'class.termId': termId } };
+
+    // Constuct compound class filters
+    let classFilters = [hasSections, filterByTermId];
     if (filters) {
-      /* we want the following filters to modify the default es query
-      - NUpath
-      - college
-      - subject (= major)
-      - online
-      - sectionsAvailable
-      - classType
-      */
+      for (const [filterKey, filterValues] of Object.entries(filters)) {
+        switch (filterKey) {
+          case 'NUpath':
+            break;
+          case 'college':
+            break;
+          case 'subject':
+            break;
+          case 'online':
+            break;
+          case 'sectionAvailable':
+            break;
+          case 'classType':
+            break;
+          default:
+            macros.log(`Filter error: Invalid filter {${filterKey}: ${filterValues}}`);
+            break;
+        }
+      }
     }
 
-    // filter by NUpath
-    let filterByNUpath = null;
-    if ('NUpath' in filters) {
-      filterByNUpath = {
-        filter: {
-          terms: {
-            'class.classAttributes' : filters.college,
-          },
-        },
-      };
-    }
-
-    // filter by college
-    let filterByCollege = null;
-    if ('college' in filters) {
-      filterByCollege = {
-        filter: {
-          terms: {
-            'class.classAttributes' : filters.college,
-          },
-        },
-      };
-    }
-
-    // filter by subject
-    let filterBySubject = null;
-    if ('subject' in filters) {
-      filterBySubject = {
-        filter: {
-          terms: {
-            'class.subject' : ['CS'], // TODO change this to filters value
-          },
-        },
-        random_score: {},
-        weight: 23,
-      };
-    }
-
-    // filter by online
-    let onlineFilter = null;
-    if ('online' in filters && filters.online) {
-      onlineFilter = {
-        filter: {
-          match: {
-            'sections.online': true,
-          },
-        },
-        weight: 5,
-      };
-    }
-
-    // filter by sectionAvailable
-    let sectionAvailableFilter = null;
-    if ('sectionAvailable' in filters && filters.sectionAvailable) {
-      sectionAvailableFilter = {
-        filter: {
-          match: {
-            'sections.online': true,
-          },
-        },
-        random_score: {},
-        weight: 23,
-      };
-    }
-
-    // filter by class type
-    let classTypeFilter = null;
-    if ('classType' in filters) {
-      classTypeFilter = {
-        filter: {
-          match: {
-            'class.scheduleType': filters.classType,
-          },
-        },
-        random_score: {},
-        weight: 23,
-      };
-    }
-
-    // remove null filters
-    const allValidFilters = [
-      // filterByNUpath,
-      // filterByCollege,
-      // filterBySubject,
-      onlineFilter,
-      // sectionAvailableFilter,
-      // classTypeFilter,
-    ].filter(eachFilter => eachFilter != null);
-
-    // text query from the main search box
+    // Text query from the main search box
     const matchTextQuery = {
       multi_match: {
         query: query,
@@ -361,59 +291,14 @@ class Elastic {
       },
     };
 
-    // const compoundQuery = {
-    //   index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
-    //   from: min,
-    //   size: max - min,
-    //   body: {
-    //     sort: [
-    //       '_score',
-    //       { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
-    //     ],
-    //     query: {
-    //       bool: {
-    //           must: matchTextQuery,
-    //         },
-    //         filter: {
-    //           bool: {
-    //             should: [
-    //               {
-    //                 bool: {
-    //                   must: [
-    //                     { exists: { field: 'sections' } },
-    //                     { term: { 'class.termId': termId } },
-    //                     { term: { 'sections.online': true } },
-    //                     {
-    //                       bool: {
-    //                         should: [
-    //                           { match_phrase: { 'class.classAttributes': 'GS College of Science' } },
-    //                           { match_phrase: { 'class.classAttributes': 'Computer&Info Sci' } },
-    //                         ],
-    //                       },
-    //                     },
-    //                   ],
-    //                 },
-    //               },
-    //               { term: { type: 'employee' } },
-    //             ],
-    //           },
-    //         },
-    //       },
-    //     },
-    //   },
-    // };
-
     // Use lower classId has tiebreaker after relevance
     const sortByClassId = { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } };
 
-    const hasSections = { exists: { field: 'sections' } };
-
-    const matchTermId = { term: { 'class.termId': termId } };
-
+    // Filter by type employee
     const isEmployee = { term: { type: 'employee' } };
 
-    // compound query for text query and filters
-    const compoundQuery = await client.search({
+    // Compound query for text query and filters
+    const mainQuery = {
       index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
       from: min,
       size: max - min,
@@ -422,25 +307,14 @@ class Elastic {
         query: {
           bool: {
             must: matchTextQuery,
-            filter: {
-              bool: {
-                should: [
-                  {
-                    bool:{
-                      must: [hasSections, matchTermId],
-                    },
-                  },
-                  isEmployee,
-                ],
-              },
-            },
+            filter: { bool: { should: [{ bool:{ must: classFilters } }, isEmployee] } },
           },
         },
       },
-    });
+    };
 
-    macros.log(JSON.stringify(compoundQuery));
-    const searchOutput = await client.search(compoundQuery);
+    macros.log(JSON.stringify(mainQuery));
+    const searchOutput = await client.search(mainQuery);
 
     return {
       searchContent: searchOutput.body.hits.hits.map((hit) => { return { ...hit._source, score: hit._score }; }),

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -335,6 +335,20 @@ class Elastic {
       macros.log(filters);
     }
 
+    // filter by college {'college': ['Computer&Info Sci']}
+    let filterByCollege = null;
+    if ('college' in filters) {
+      filterByCollege = {
+        bool: {
+          filter: {
+            terms: {
+              'class.classAttributes' : filters.college,
+            },
+          },
+        },
+      };
+    }
+
     // query from the main search box
     const searchBoxQuery = {
       bool: {
@@ -356,20 +370,6 @@ class Elastic {
         },
       },
     };
-
-    // filter by college {'college': ['Computer&Info Sci']}
-    let filterByCollege = null;
-    if ('college' in filters) {
-      filterByCollege = {
-        bool: {
-          filter: {
-            terms: {
-              'class.classAttributes' : ['Computer&Info Sci'],
-            },
-          },
-        },
-      };
-    }
 
     // remove null filters
     const queryWithFilters = [

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -221,7 +221,7 @@ class Elastic {
   /**
    * Remove any invalid filter with the following criteria:
    * 1. Correct key string and value type;
-   * 2. Check that { online: false } should not never be in filters
+   * 2. Check that { online: false } should never be in filters
    *
    * A sample filters JSON object has the following format:
    * { 'NUpath': string[],

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -354,7 +354,7 @@ class Elastic {
 
     // get compound class filters
     const validFilters = this.validateFilters(filters);
-    const satisfyClassFilters = this.getClassFilterQuery(termId, validFilters);
+    const classFilters = this.getClassFilterQuery(termId, validFilters);
 
     // text query from the main search box
     const matchTextQuery = {
@@ -385,7 +385,7 @@ class Elastic {
             filter: {
               bool: {
                 should: [
-                  satisfyClassFilters,
+                  classFilters,
                   isEmployee,
                 ],
               },

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -309,8 +309,7 @@ class Elastic {
             'sections.online': true,
           },
         },
-        random_score: {},
-        weight: 23,
+        weight: 5,
       };
     }
 
@@ -344,12 +343,12 @@ class Elastic {
 
     // remove null filters
     const allValidFilters = [
-      filterByNUpath,
-      filterByCollege,
-      filterBySubject,
+      // filterByNUpath,
+      // filterByCollege,
+      // filterBySubject,
       onlineFilter,
-      sectionAvailableFilter,
-      classTypeFilter,
+      // sectionAvailableFilter,
+      // classTypeFilter,
     ].filter(eachFilter => eachFilter != null);
 
     // text query from the main search box
@@ -376,8 +375,34 @@ class Elastic {
       },
     };
 
-    // combine main query and filters, using function_score to only filter on class with matching query score
-    const prevTestQuery = {
+    // ensure result pass at least one filter when filters exist
+    const minScore = allValidFilters.length > 0 ? 100 : 5;
+
+    // compound query for text query and filters
+    const esQuery = {
+      index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
+      // from: min,
+      // size: max - min,
+      body: {
+        sort: [
+          '_score',
+          { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
+        ],
+        query: {
+          function_score: { // Use function_score to only filter on class with matching query
+            query: searchBoxQuery,
+            // boost: 5,
+            functions: allValidFilters,
+            // max_boost: 100,
+            score_mode: 'max',
+            boost_mode: 'sum',
+            min_score: minScore,
+          },
+        },
+      },
+    };
+
+    const prevQuery = {
       index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
       from: min,
       size: max - min,
@@ -387,21 +412,46 @@ class Elastic {
           { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
         ],
         query: {
-          function_score: {
-            query: searchBoxQuery,
-            boost: 5,
-            functions: allValidFilters,
-            max_boost: 42,
-            score_mode: 'max',
-            boost_mode: 'multiply',
-            min_score: 42,
+          bool: {
+            must: {
+              multi_match: {
+                query: query,
+                type: 'most_fields', // More fields match => higher score
+                fuzziness: 'AUTO',
+                fields: fields,
+              },
+            },
+            filter: {
+              bool: {
+                should: [
+                  {
+                    bool: {
+                      must: [
+                        { exists: { field: 'sections' } },
+                        { term: { 'class.termId': termId } },
+                        { term: { 'sections.online': true } },
+                        {
+                          bool: {
+                            should: [
+                              { match_phrase: { 'class.classAttributes': 'GS College of Science' } },
+                              { match_phrase: { 'class.classAttributes': 'Computer&Info Sci' } },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  { term: { type: 'employee' } },
+                ],
+              },
+            },
           },
         },
       },
     };
 
-    macros.log(JSON.stringify(prevTestQuery));
-    const searchOutput = await client.search(prevTestQuery);
+    macros.log(JSON.stringify(prevQuery));
+    const searchOutput = await client.search(prevQuery);
 
     return {
       searchContent: searchOutput.body.hits.hits.map((hit) => { return { ...hit._source, score: hit._score }; }),
@@ -413,3 +463,57 @@ class Elastic {
 
 const instance = new Elastic();
 export default instance;
+
+/*
+curl -X GET "localhost:9200/classes/_search?pretty" -H 'Content-Type: application/json' -d'
+{
+  "query": {
+    "bool": {
+      "must": {
+        "multi_match": {
+          "query": "cs 2500",
+          "type": "most_fields",
+          "fuzziness": "AUTO",
+          "fields": [
+            "class.subject^10",
+            "class.classId"
+          ]
+        }
+      },
+      "filter": {
+        "bool": {
+          "should": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "exists": {
+                      "field": "sections"
+                    }
+                  },
+                  {
+                    "term": {
+                      "class.termId": "202010"
+                    }
+                  },
+                  {
+                    "term": {
+                      "sections.online": true
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "term": {
+                "type": "employee"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+'
+ */

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -257,7 +257,7 @@ class Elastic {
     // Filter by term
     const filterByTermId = { term: { 'class.termId': termId } };
 
-    // Constuct compound class filters
+    // Constuct compound class filters (fliters joined by AND (must), options for a filter joined by OR (should))
     const classFilters = [hasSections, filterByTermId];
     if ('NUpath' in filters) {
       const NUpathFilters = filters.NUpath.map(attribute => ({ match_phrase: { 'class.classAttributes': attribute } }));
@@ -269,13 +269,13 @@ class Elastic {
     }
     if ('subject' in filters) {
       const subjectFilters = filters.subject.map(eachSubject => ({ match: { 'class.subject': eachSubject } }));
-      classFilters.push(subjectFilters);
+      classFilters.push({ bool: { should: subjectFilters } });
     }
     if ('online' in filters && filters.online) {
       classFilters.push({ term: { 'sections.online': true } });
     }
     if ('classType' in filters) {
-      classFilters.push({ term: { 'sections.online': filters.classType } });
+      classFilters.push({ match: { 'class.scheduleType': filters.classType } });
     }
 
     // Text query from the main search box
@@ -317,53 +317,6 @@ class Elastic {
       },
     };
 
-    const texst = {
-      index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
-      from: min,
-      size: max - min,
-      body: {
-        sort: [
-          '_score',
-          { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
-        ],
-        query: {
-          bool: {
-            must: {
-              multi_match: {
-                query: query,
-                type: 'most_fields', // More fields match => higher score
-                fuzziness: 'AUTO',
-                fields: fields,
-              },
-            },
-            filter: {
-              bool: {
-                should: [
-                  {
-                    bool: {
-                      must: [
-                        { exists: { field: 'sections' } },
-                        { term: { 'class.termId': termId } },
-                        {
-                          bool: {
-                            should: [
-                              { match_phrase: { 'class.classAttributes': termId } },
-                            ],
-                          },
-                        },
-                      ],
-                    },
-                  },
-                  { term: { type: 'employee' } },
-                ],
-              },
-            },
-          },
-        },
-      },
-    }
-
-    macros.log(JSON.stringify(mainQuery));
     const searchOutput = await client.search(mainQuery);
 
     return {

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -329,43 +329,104 @@ class Elastic {
       /* we want the following filters to modify the default es query
       - NUpath
       - college
-      - major
+      - subject (= major)
       - online
-      - subject
       - sectionsAvailable
       - classType
       */
+    }
+
+    // filter by NUpath
+    let filterByNUpath = null;
+    if ('NUpath' in filters) {
+      filterByNUpath = {
+        filter: {
+          terms: {
+            'class.classAttributes' : filters.college,
+          },
+        },
+      };
     }
 
     // filter by college
     let filterByCollege = null;
     if ('college' in filters) {
       filterByCollege = {
-        bool: {
-          filter: {
-            terms: {
-              'class.classAttributes' : filters.college,
-            },
+        filter: {
+          terms: {
+            'class.classAttributes' : filters.college,
           },
         },
       };
     }
 
-    // filter by major
+    // filter by subject
     let filterBySubject = null;
-    if ('major' in filters) {
+    if ('subject' in filters) {
       filterBySubject = {
-        bool: {
-          filter: {
-            terms: {
-              'class.subject' : ['CS'], // TODO change this to filters value
-            },
+        filter: {
+          terms: {
+            'class.subject' : ['CS'], // TODO change this to filters value
           },
         },
+        random_score: {},
+        weight: 23,
       };
     }
 
-    // query from the main search box
+    // filter by online
+    let onlineFilter = null;
+    if ('online' in filters && filters.online) {
+      onlineFilter = {
+        filter: {
+          match: {
+            'sections.online': true,
+          },
+        },
+        random_score: {},
+        weight: 23,
+      };
+    }
+
+    // filter by sectionAvailable
+    let sectionAvailableFilter = null;
+    if ('sectionAvailable' in filters && filters.sectionAvailable) {
+      sectionAvailableFilter = {
+        filter: {
+          match: {
+            'sections.online': true,
+          },
+        },
+        random_score: {},
+        weight: 23,
+      };
+    }
+
+    // filter by class type
+    let classTypeFilter = null;
+    if ('classType' in filters) {
+      classTypeFilter = {
+        filter: {
+          match: {
+            'class.scheduleType': filters.classType,
+          },
+        },
+        random_score: {},
+        weight: 23,
+      };
+    }
+
+    // remove null filters
+    const allValidFilters = [
+      filterByNUpath,
+      filterByCollege,
+      filterBySubject,
+      onlineFilter,
+      sectionAvailableFilter,
+      classTypeFilter,
+    ].filter(eachFilter => eachFilter != null);
+
+    // text query from the main search box
     const searchBoxQuery = {
       bool: {
         must: [
@@ -389,149 +450,29 @@ class Elastic {
       },
     };
 
-    // remove null filters
-    const queryWithFilters = [
-      searchBoxQuery,
-      filterByCollege,
-      filterBySubject,
-    ].filter(eachFilter => eachFilter != null);
-
-    // combine main query and filters
-    const elasticsearchQuery = {
+    // combine main query and filters, using function_score to only filter on class with matching query score
+    const prevTestQuery = {
       index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
       from: min,
       size: max - min,
       body: {
         sort: ['_score', sortByClassId],
         query: {
-          bool: {
-            must: queryWithFilters,
+          function_score: {
+            query: searchBoxQuery,
+            boost: 5,
+            functions: allValidFilters,
+            max_boost: 42,
+            score_mode: 'max',
+            boost_mode: 'multiply',
+            min_score: 42,
           },
         },
       },
     };
 
-    const originalQuery = {
-      index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
-      from: min,
-      size: max - min,
-      body: {
-        sort: [
-          '_score',
-          { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
-        ],
-        query: {
-          bool: {
-            must: [
-              {
-                multi_match: {
-                  query: query,
-                  type: 'most_fields', // More fields match => higher score
-                  fuzziness: 'AUTO',
-                  fields: fields,
-                },
-              },
-              // {
-              //   match: {
-              //     'class.subject': 'EECE',
-              //   },
-              // },
-            ],
-            filter: {
-              bool: {
-                should: [
-                  {
-                    bool:{
-                      must: [
-                        { exists: { field: 'sections' } },
-                        { term: { 'class.termId': termId } },
-                      ],
-                    },
-                  },
-                  { term: { type: 'employee' } },
-                ],
-              },
-            },
-          },
-        },
-      },
-    };
-
-    const prevQuery = {
-      index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
-      from: min,
-      size: max - min,
-      body: {
-        sort: [
-          '_score',
-          { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
-        ],
-        query: {
-          bool: {
-            must: {
-              multi_match: {
-                query: query,
-                type: 'most_fields', // More fields match => higher score
-                fuzziness: 'AUTO',
-                fields: fields,
-              },
-            },
-            filter: {
-              bool: {
-                should: [
-                  {
-                    bool:{
-                      must: [
-                        { exists: { field: 'sections' } },
-                        { term: { 'class.termId': termId } },
-                      ],
-                    },
-                  },
-                  { term: { type: 'employee' } },
-                ],
-              },
-            },
-          },
-        },
-      },
-    };
-
-
-    const testQuery = {
-      index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
-      from: 0,
-      size: 1000,
-      body: {
-        query: {
-          constant_score: {
-            filter: {
-              bool: {
-                must: [
-                  // {
-                  //   match: {
-                  //     'sections.online': true,
-                  //   },
-                  // },
-                  {
-                    match_phrase: {
-                      'class.scheduleType': 'Lab',
-                    },
-                  },
-                  // {
-                  //   match_phrase: {
-                  //     'class.classAttributes': 'GSEN Engineering',
-                  //   },
-                  // },
-                ],
-              },
-            },
-          },
-        },
-      },
-    };
-
-    macros.log(JSON.stringify(testQuery));
-    const searchOutput = await client.search(testQuery);
+    macros.log(JSON.stringify(prevTestQuery));
+    const searchOutput = await client.search(prevTestQuery);
 
     return {
       searchContent: searchOutput.body.hits.hits.map((hit) => { return { ...hit._source, score: hit._score }; }),
@@ -543,18 +484,3 @@ class Elastic {
 
 const instance = new Elastic();
 export default instance;
-
-/*
-
-
-curl -X GET "localhost:9200/classes/_search?pretty" -H 'Content-Type: application/json' -d'
-{
-  "query": {
-    "match": {
-      "sections.online": true
-    }
-  }
-}
-'
-
-*/

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -261,6 +261,20 @@ class Elastic {
       macros.log(filters);
     }
 
+    // filter by college {'college': ['Computer&Info Sci']}
+    let filterByCollege = null;
+    if ('college' in filters) {
+      filterByCollege = {
+        bool: {
+          filter: {
+            terms: {
+              'class.classAttributes' : filters.college,
+            },
+          },
+        },
+      };
+    }
+
     // query from the main search box
     const searchBoxQuery = {
       bool: {
@@ -282,20 +296,6 @@ class Elastic {
         },
       },
     };
-
-    // filter by college {'college': ['Computer&Info Sci']}
-    let filterByCollege = null;
-    if ('college' in filters) {
-      filterByCollege = {
-        bool: {
-          filter: {
-            terms: {
-              'class.classAttributes' : ['Computer&Info Sci'],
-            },
-          },
-        },
-      };
-    }
 
     // remove null filters
     const queryWithFilters = [

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -306,34 +306,58 @@ class Elastic {
       fields = ['class.subject^10', 'class.classId'];
     }
 
-    // Filter classes to get those with sections
+    // filter classes to get those with sections
     const hasSections = { exists: { field: 'sections' } };
 
-    // Filter by term
+    // filter by term
     const filterByTermId = { term: { 'class.termId': termId } };
 
-    // Constuct compound class filters (fliters joined by AND (must), options for a filter joined by OR (should))
+    const getNUpathFilter = (selectedNUpaths) => {
+      const NUpathFilters = selectedNUpaths.map(eachNUpath => ({ match_phrase: { 'class.classAttributes': eachNUpath } }));
+      return { bool: { should: NUpathFilters } };
+    };
+
+    const getCollegeFilter = (selectedColleges) => {
+      const collegeFilters = selectedColleges.map(eachCollege => ({ match_phrase: { 'class.classAttributes': eachCollege } }));
+      return { bool: { should: collegeFilters } };
+    };
+
+    const getSubjectFilter = (selectedSubject) => {
+      const subjectFilters = selectedSubject.map(eachSubject => ({ match: { 'class.subject': eachSubject } }));
+      return { bool: { should: subjectFilters } };
+    };
+
+    // note that { online: false } should not never be in filters
+    const getOnlineFilter = (selectedOnlineOption) => {
+      return { term: { 'sections.online': selectedOnlineOption } };
+    };
+
+    const getClassTypeFilter = (selectedClassType) => {
+      return { match: { 'class.scheduleType': selectedClassType } };
+    };
+
+    // construct compound class filters (fliters joined by AND (must), options for a filter joined by OR (should))
+    const filterToEsQuery = {
+      NUpath: getNUpathFilter,
+      college: getCollegeFilter,
+      subject: getSubjectFilter,
+      online: getOnlineFilter,
+      classType: getClassTypeFilter,
+    };
+
     const classFilters = [hasSections, filterByTermId];
-    if ('NUpath' in filters) {
-      const NUpathFilters = filters.NUpath.map(attribute => ({ match_phrase: { 'class.classAttributes': attribute } }));
-      classFilters.push({ bool: { should: NUpathFilters } });
-    }
-    if ('college' in filters) {
-      const collegeFilters = filters.college.map(attribute => ({ match_phrase: { 'class.classAttributes': attribute } }));
-      classFilters.push({ bool: { should: collegeFilters } });
-    }
-    if ('subject' in filters) {
-      const subjectFilters = filters.subject.map(eachSubject => ({ match: { 'class.subject': eachSubject } }));
-      classFilters.push({ bool: { should: subjectFilters } });
-    }
-    if ('online' in filters && filters.online) {
-      classFilters.push({ term: { 'sections.online': true } });
-    }
-    if ('classType' in filters) {
-      classFilters.push({ match: { 'class.scheduleType': filters.classType } });
+    for (const [filterKey, filterValues] of Object.entries(filters)) {
+      if (filterKey in filterToEsQuery) {
+        macros.log(`Filter: {${filterKey}: ${filterValues}}`);
+        macros.log(`Type: ${typeof filterToEsQuery[filterKey]}`);
+        macros.log(`Type: ${typeof filterToEsQuery.filterKey}`);
+        classFilters.push(filterToEsQuery[filterKey](filterValues));
+      } else {
+        macros.log(`Invalid filter: {${filterKey}: ${filterValues}}`);
+      }
     }
 
-    // Text query from the main search box
+    // text query from the main search box
     const matchTextQuery = {
       multi_match: {
         query: query,
@@ -343,13 +367,13 @@ class Elastic {
       },
     };
 
-    // Use lower classId has tiebreaker after relevance
+    // use lower classId has tiebreaker after relevance
     const sortByClassId = { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } };
 
-    // Filter by type employee
+    // filter by type employee
     const isEmployee = { term: { type: 'employee' } };
 
-    // Compound query for text query and filters
+    // compound query for text query and filters
     const mainQuery = {
       index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
       from: min,

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -352,106 +352,95 @@ class Elastic {
     ].filter(eachFilter => eachFilter != null);
 
     // text query from the main search box
-    const searchBoxQuery = {
-      bool: {
-        must: [
-          {
-            multi_match: {
-              query: query,
-              type: 'most_fields', // More fields match => higher score
-              fuzziness: 'AUTO',
-              fields: fields,
-            },
-          },
-        ],
-        filter: {
-          bool: {
-            should: [
-              { term: { 'class.termId': termId } },
-              { term: { type: 'employee' } },
-            ],
-          },
-        },
+    const matchTextQuery = {
+      multi_match: {
+        query: query,
+        type: 'most_fields', // More fields match => higher score
+        fuzziness: 'AUTO',
+        fields: fields,
       },
     };
 
-    // ensure result pass at least one filter when filters exist
-    const minScore = allValidFilters.length > 0 ? 100 : 5;
+    // const compoundQuery = {
+    //   index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
+    //   from: min,
+    //   size: max - min,
+    //   body: {
+    //     sort: [
+    //       '_score',
+    //       { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
+    //     ],
+    //     query: {
+    //       bool: {
+    //           must: matchTextQuery,
+    //         },
+    //         filter: {
+    //           bool: {
+    //             should: [
+    //               {
+    //                 bool: {
+    //                   must: [
+    //                     { exists: { field: 'sections' } },
+    //                     { term: { 'class.termId': termId } },
+    //                     { term: { 'sections.online': true } },
+    //                     {
+    //                       bool: {
+    //                         should: [
+    //                           { match_phrase: { 'class.classAttributes': 'GS College of Science' } },
+    //                           { match_phrase: { 'class.classAttributes': 'Computer&Info Sci' } },
+    //                         ],
+    //                       },
+    //                     },
+    //                   ],
+    //                 },
+    //               },
+    //               { term: { type: 'employee' } },
+    //             ],
+    //           },
+    //         },
+    //       },
+    //     },
+    //   },
+    // };
+
+    // Use lower classId has tiebreaker after relevance
+    const sortByClassId = { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } };
+
+    const hasSections = { exists: { field: 'sections' } };
+
+    const matchTermId = { term: { 'class.termId': termId } };
+
+    const isEmployee = { term: { type: 'employee' } };
 
     // compound query for text query and filters
-    const esQuery = {
-      index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
-      // from: min,
-      // size: max - min,
-      body: {
-        sort: [
-          '_score',
-          { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
-        ],
-        query: {
-          function_score: { // Use function_score to only filter on class with matching query
-            query: searchBoxQuery,
-            // boost: 5,
-            functions: allValidFilters,
-            // max_boost: 100,
-            score_mode: 'max',
-            boost_mode: 'sum',
-            min_score: minScore,
-          },
-        },
-      },
-    };
-
-    const prevQuery = {
+    const compoundQuery = await client.search({
       index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
       from: min,
       size: max - min,
       body: {
-        sort: [
-          '_score',
-          { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
-        ],
+        sort: ['_score', sortByClassId],
         query: {
           bool: {
-            must: {
-              multi_match: {
-                query: query,
-                type: 'most_fields', // More fields match => higher score
-                fuzziness: 'AUTO',
-                fields: fields,
-              },
-            },
+            must: matchTextQuery,
             filter: {
               bool: {
                 should: [
                   {
-                    bool: {
-                      must: [
-                        { exists: { field: 'sections' } },
-                        { term: { 'class.termId': termId } },
-                        { term: { 'sections.online': true } },
-                        {
-                          bool: {
-                            should: [
-                              { match_phrase: { 'class.classAttributes': 'GS College of Science' } },
-                              { match_phrase: { 'class.classAttributes': 'Computer&Info Sci' } },
-                            ],
-                          },
-                        },
-                      ],
+                    bool:{
+                      must: [hasSections, matchTermId],
                     },
                   },
-                  { term: { type: 'employee' } },
+                  isEmployee,
                 ],
               },
             },
           },
         },
       },
-    };
+    });
 
-    macros.log(JSON.stringify(prevQuery));
-    const searchOutput = await client.search(prevQuery);
+    macros.log(JSON.stringify(compoundQuery));
+    const searchOutput = await client.search(compoundQuery);
 
     return {
       searchContent: searchOutput.body.hits.hits.map((hit) => { return { ...hit._source, score: hit._score }; }),
@@ -463,57 +452,3 @@ class Elastic {
 
 const instance = new Elastic();
 export default instance;
-
-/*
-curl -X GET "localhost:9200/classes/_search?pretty" -H 'Content-Type: application/json' -d'
-{
-  "query": {
-    "bool": {
-      "must": {
-        "multi_match": {
-          "query": "cs 2500",
-          "type": "most_fields",
-          "fuzziness": "AUTO",
-          "fields": [
-            "class.subject^10",
-            "class.classId"
-          ]
-        }
-      },
-      "filter": {
-        "bool": {
-          "should": [
-            {
-              "bool": {
-                "must": [
-                  {
-                    "exists": {
-                      "field": "sections"
-                    }
-                  },
-                  {
-                    "term": {
-                      "class.termId": "202010"
-                    }
-                  },
-                  {
-                    "term": {
-                      "sections.online": true
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "term": {
-                "type": "employee"
-              }
-            }
-          ]
-        }
-      }
-    }
-  }
-}
-'
- */

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -14,61 +14,6 @@ const client = new Client({ node: URL });
 
 const BULKSIZE = 5000;
 
-/**
-   * Get elasticsearch query from json filters and termId
-   * @param  {string}  termId  The termId to look within
-   * @param  {object}  filters The json object representing all filters
-   */
-function getClassFilterQuery(termId, filters) {
-  // filter classes to get those with sections
-  const hasSections = { exists: { field: 'sections' } };
-
-  // filter by term
-  const filterByTermId = { term: { 'class.termId': termId } };
-
-  const getNUpathFilter = (selectedNUpaths) => {
-    const NUpathFilters = selectedNUpaths.map(eachNUpath => ({ match_phrase: { 'class.classAttributes': eachNUpath } }));
-    return { bool: { should: NUpathFilters } };
-  };
-
-  const getCollegeFilter = (selectedColleges) => {
-    const collegeFilters = selectedColleges.map(eachCollege => ({ match_phrase: { 'class.classAttributes': eachCollege } }));
-    return { bool: { should: collegeFilters } };
-  };
-
-  const getSubjectFilter = (selectedSubject) => {
-    const subjectFilters = selectedSubject.map(eachSubject => ({ match: { 'class.subject': eachSubject } }));
-    return { bool: { should: subjectFilters } };
-  };
-
-  // note that { online: false } should not never be in filters
-  const getOnlineFilter = (selectedOnlineOption) => {
-    return { term: { 'sections.online': selectedOnlineOption } };
-  };
-
-  const getClassTypeFilter = (selectedClassType) => {
-    return { match: { 'class.scheduleType': selectedClassType } };
-  };
-
-  // construct compound class filters (fliters joined by AND (must), options for a filter joined by OR (should))
-  const filterToEsQuery = {
-    NUpath: getNUpathFilter,
-    college: getCollegeFilter,
-    subject: getSubjectFilter,
-    online: getOnlineFilter,
-    classType: getClassTypeFilter,
-  };
-
-  const classFilters = [hasSections, filterByTermId];
-  for (const [filterKey, filterValues] of Object.entries(filters)) {
-    if (filterKey in filterToEsQuery) {
-      classFilters.push(filterToEsQuery[filterKey](filterValues));
-    }
-  }
-
-  return classFilters;
-}
-
 class Elastic {
   constructor() {
     // Because we export an instance of this class, put the constants on the instance.
@@ -274,6 +219,61 @@ class Elastic {
   }
 
   /**
+   * Get elasticsearch query from json filters and termId
+   * @param  {string}  termId  The termId to look within
+   * @param  {object}  filters The json object representing all filters
+   */
+  getClassFilterQuery(termId, filters) {
+    // filter classes to get those with sections
+    const hasSections = { exists: { field: 'sections' } };
+
+    // filter by term
+    const filterByTermId = { term: { 'class.termId': termId } };
+
+    const getNUpathFilter = (selectedNUpaths) => {
+      const NUpathFilters = selectedNUpaths.map(eachNUpath => ({ match_phrase: { 'class.classAttributes': eachNUpath } }));
+      return { bool: { should: NUpathFilters } };
+    };
+
+    const getCollegeFilter = (selectedColleges) => {
+      const collegeFilters = selectedColleges.map(eachCollege => ({ match_phrase: { 'class.classAttributes': eachCollege } }));
+      return { bool: { should: collegeFilters } };
+    };
+
+    const getSubjectFilter = (selectedSubject) => {
+      const subjectFilters = selectedSubject.map(eachSubject => ({ match: { 'class.subject': eachSubject } }));
+      return { bool: { should: subjectFilters } };
+    };
+
+    // note that { online: false } should not never be in filters
+    const getOnlineFilter = (selectedOnlineOption) => {
+      return { term: { 'sections.online': selectedOnlineOption } };
+    };
+
+    const getClassTypeFilter = (selectedClassType) => {
+      return { match: { 'class.scheduleType': selectedClassType } };
+    };
+
+    // construct compound class filters (fliters joined by AND (must), options for a filter joined by OR (should))
+    const filterToEsQuery = {
+      NUpath: getNUpathFilter,
+      college: getCollegeFilter,
+      subject: getSubjectFilter,
+      online: getOnlineFilter,
+      classType: getClassTypeFilter,
+    };
+
+    const classFilters = [hasSections, filterByTermId];
+    for (const [filterKey, filterValues] of Object.entries(filters)) {
+      if (filterKey in filterToEsQuery) {
+        classFilters.push(filterToEsQuery[filterKey](filterValues));
+      }
+    }
+
+    return classFilters;
+  }
+
+  /**
    * Search for classes and employees
    * @param  {string}  query   The search to query for
    * @param  {string}  termId  The termId to look within
@@ -307,7 +307,7 @@ class Elastic {
     }
 
     // get compound class filters
-    const classFilters = getClassFilterQuery(termId, filters);
+    const classFilters = this.getClassFilterQuery(termId, filters);
 
     // text query from the main search box
     const matchTextQuery = {

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -14,61 +14,6 @@ const client = new Client({ node: URL });
 
 const BULKSIZE = 5000;
 
-/**
-   * Get elasticsearch query from json filters and termId
-   * @param  {string}  termId  The termId to look within
-   * @param  {object}  filters The json object representing all filters
-   */
-function getClassFilterQuery(termId, filters) {
-  // filter classes to get those with sections
-  const hasSections = { exists: { field: 'sections' } };
-
-  // filter by term
-  const filterByTermId = { term: { 'class.termId': termId } };
-
-  const getNUpathFilter = (selectedNUpaths) => {
-    const NUpathFilters = selectedNUpaths.map(eachNUpath => ({ match_phrase: { 'class.classAttributes': eachNUpath } }));
-    return { bool: { should: NUpathFilters } };
-  };
-
-  const getCollegeFilter = (selectedColleges) => {
-    const collegeFilters = selectedColleges.map(eachCollege => ({ match_phrase: { 'class.classAttributes': eachCollege } }));
-    return { bool: { should: collegeFilters } };
-  };
-
-  const getSubjectFilter = (selectedSubject) => {
-    const subjectFilters = selectedSubject.map(eachSubject => ({ match: { 'class.subject': eachSubject } }));
-    return { bool: { should: subjectFilters } };
-  };
-
-  // note that { online: false } should not never be in filters
-  const getOnlineFilter = (selectedOnlineOption) => {
-    return { term: { 'sections.online': selectedOnlineOption } };
-  };
-
-  const getClassTypeFilter = (selectedClassType) => {
-    return { match: { 'class.scheduleType': selectedClassType } };
-  };
-
-  // construct compound class filters (fliters joined by AND (must), options for a filter joined by OR (should))
-  const filterToEsQuery = {
-    NUpath: getNUpathFilter,
-    college: getCollegeFilter,
-    subject: getSubjectFilter,
-    online: getOnlineFilter,
-    classType: getClassTypeFilter,
-  };
-
-  const classFilters = [hasSections, filterByTermId];
-  for (const [filterKey, filterValues] of Object.entries(filters)) {
-    if (filterKey in filterToEsQuery) {
-      classFilters.push(filterToEsQuery[filterKey](filterValues));
-    }
-  }
-
-  return classFilters;
-}
-
 class Elastic {
   constructor() {
     // Because we export an instance of this class, put the constants on the instance.
@@ -362,7 +307,7 @@ class Elastic {
     }
 
     // get compound class filters
-    const classFilters = getClassFilterQuery(termId, filters);
+    const classFilters = this.getClassFilterQuery(termId, filters);
 
     // text query from the main search box
     const matchTextQuery = {

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -62,12 +62,7 @@ function getClassFilterQuery(termId, filters) {
   const classFilters = [hasSections, filterByTermId];
   for (const [filterKey, filterValues] of Object.entries(filters)) {
     if (filterKey in filterToEsQuery) {
-      macros.log(`Filter: {${filterKey}: ${filterValues}}`);
-      macros.log(`Type: ${typeof filterToEsQuery[filterKey]}`);
-      macros.log(`Type: ${typeof filterToEsQuery.filterKey}`);
       classFilters.push(filterToEsQuery[filterKey](filterValues));
-    } else {
-      macros.log(`Invalid filter: {${filterKey}: ${filterValues}}`);
     }
   }
 

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -326,16 +326,18 @@ class Elastic {
     const isEmployee = { term: { type: 'employee' } };
 
     if (filters) {
-      /* we want the follwoing filters to modify the default es query
+      /* we want the following filters to modify the default es query
       - NUpath
       - college
       - major
       - online
+      - subject
+      - sectionsAvailable
+      - classType
       */
-      macros.log(filters);
     }
 
-    // filter by college {'college': ['Computer&Info Sci']}
+    // filter by college
     let filterByCollege = null;
     if ('college' in filters) {
       filterByCollege = {
@@ -349,17 +351,33 @@ class Elastic {
       };
     }
 
+    // filter by major
+    let filterBySubject = null;
+    if ('major' in filters) {
+      filterBySubject = {
+        bool: {
+          filter: {
+            terms: {
+              'class.subject' : ['CS'], // TODO change this to filters value
+            },
+          },
+        },
+      };
+    }
+
     // query from the main search box
     const searchBoxQuery = {
       bool: {
-        must: {
-          multi_match: {
-            query: query,
-            type: 'most_fields', // More fields match => higher score
-            fuzziness: 'AUTO',
-            fields: fields,
+        must: [
+          {
+            multi_match: {
+              query: query,
+              type: 'most_fields', // More fields match => higher score
+              fuzziness: 'AUTO',
+              fields: fields,
+            },
           },
-        },
+        ],
         filter: {
           bool: {
             should: [
@@ -375,6 +393,7 @@ class Elastic {
     const queryWithFilters = [
       searchBoxQuery,
       filterByCollege,
+      filterBySubject,
     ].filter(eachFilter => eachFilter != null);
 
     // combine main query and filters
@@ -392,7 +411,57 @@ class Elastic {
       },
     };
 
-    const searchOutput = await client.search(elasticsearchQuery);
+    const originalQuery = {
+      index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
+      from: min,
+      size: max - min,
+      body: {
+        sort: [
+          '_score',
+          { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
+        ],
+        query: {
+          bool: {
+            must: [
+              {
+                multi_match: {
+                  query: query,
+                  type: 'most_fields', // More fields match => higher score
+                  fuzziness: 'AUTO',
+                  fields: fields,
+                },
+              },
+              // {
+              //   match: {
+              //     'class.subject': 'EECE',
+              //   },
+              // },
+            ],
+            filter: {
+              bool: {
+                should: [
+                  {
+                    bool:{
+                      must: [
+                        { exists: { field: 'sections' } },
+                        { term: { 'class.termId': termId } },
+                      ],
+                    },
+                  },
+                  { term: { type: 'employee' } },
+                ],
+              },
+            },
+            should: [
+              { term: { 'class.subject': 'EECE' } },
+            ],
+          },
+        },
+      },
+    };
+
+    macros.log(JSON.stringify(originalQuery));
+    const searchOutput = await client.search(originalQuery);
 
     return {
       searchContent: searchOutput.body.hits.hits.map((hit) => { return { ...hit._source, score: hit._score }; }),

--- a/backend/server.js
+++ b/backend/server.js
@@ -245,16 +245,15 @@ app.get('/search', wrap(async (req, res) => {
       res.send(JSON.stringify({
         error: 'Invalid filters.',
       }));
-      return;
-    }
-    try {
-      filters = JSON.parse(req.query.filters);
-    } catch (e) {
-      macros.log('Invalid filters JSON.', req.filters);
-      res.send(JSON.stringify({
-        error: 'Invalid filters.',
-      }));
-      return;
+    } else {
+      try {
+        filters = JSON.parse(req.query.filters);
+      } catch (e) {
+        macros.log('Invalid filters JSON.', req.filters);
+        res.send(JSON.stringify({
+          error: 'Invalid filters.',
+        }));
+      }
     }
   }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -241,38 +241,20 @@ app.get('/search', wrap(async (req, res) => {
   if (req.query.filters) {
     // Ensure filters is a string
     if (typeof req.query.filters !== 'string') {
-      macros.log(getTime(), 'Invalid filters.', req.filters);
+      macros.log('Invalid filters.', req.filters);
       res.send(JSON.stringify({
         error: 'Invalid filters.',
       }));
       return;
     }
-    filters = JSON.parse(req.query.filters);
-
-
-    // Ensure filter key and value type are valid
-    const validFilters = {
-      NUpath: 'object',
-      college: 'object',
-      subject: 'object',
-      online: 'string',
-      classType: 'string',
-    };
-    for (const [filterKey, filterValues] of Object.entries(filters)) {
-      if (!(filterKey in validFilters)) {
-        macros.log(getTime(), 'Invalid filter key.', filterKey);
-        res.send(JSON.stringify({
-          error: 'Invalid filter key.',
-        }));
-        return;
-      }
-      if (typeof filterValues !== validFilters[filterKey]) { // eslint-disable-line valid-typeof
-        macros.log(getTime(), `Invalid type of filter value ${typeof filterValues} for ${filterKey}.`);
-        res.send(JSON.stringify({
-          error: 'Invalid type of filter value.',
-        }));
-        return;
-      }
+    try {
+      filters = JSON.parse(req.query.filters);
+    } catch (e) {
+      macros.log('Invalid filters JSON.', req.filters);
+      res.send(JSON.stringify({
+        error: 'Invalid filters.',
+      }));
+      return;
     }
   }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -257,7 +257,7 @@ app.get('/search', wrap(async (req, res) => {
       subject: 'object',
       online: 'string',
       classType: 'string',
-    }
+    };
     for (const [filterKey, filterValues] of Object.entries(filters)) {
       if (!filterKey in validFilters) {
         macros.log(getTime(), 'Invalid filter key.', filterKey);

--- a/backend/server.js
+++ b/backend/server.js
@@ -239,7 +239,6 @@ app.get('/search', wrap(async (req, res) => {
 
   let filters = {};
   if (req.query.filters) {
-
     // Ensure filters is a string
     if (typeof req.query.filters !== 'string') {
       macros.log(getTime(), 'Invalid filters.', req.filters);

--- a/backend/server.js
+++ b/backend/server.js
@@ -249,15 +249,24 @@ app.get('/search', wrap(async (req, res) => {
     }
     filters = JSON.parse(req.query.filters);
 
+<<<<<<< HEAD
     // Ensure filter key and value type are valid
+=======
+>>>>>>> check for valid filters in req
     const validFilters = {
       NUpath: 'object',
       college: 'object',
       subject: 'object',
       online: 'string',
       classType: 'string',
+<<<<<<< HEAD
     };
     for (const [filterKey, filterValues] of Object.entries(filters)) {
+=======
+    }
+    for (const [filterKey, filterValues] of Object.entries(filters)) {
+      // Ensure filters keys are valid
+>>>>>>> check for valid filters in req
       if (!filterKey in validFilters) {
         macros.log(getTime(), 'Invalid filter key.', filterKey);
         res.send(JSON.stringify({
@@ -265,8 +274,14 @@ app.get('/search', wrap(async (req, res) => {
         }));
         return;
       }
+<<<<<<< HEAD
       if (typeof filterValues !== validFilters[filterKey]) {
         macros.log(getTime(), `Invalid type of filter value ${typeof filterValues} for ${filterKey}.`);
+=======
+      // Ensure filter values are of the correct type
+      if (typeof filtersValues !== validFilters[filterKey]) {
+        macros.log(getTime(), `Invalid type of filter value ${typeof filtersValues} for ${filterKey}.`);
+>>>>>>> check for valid filters in req
         res.send(JSON.stringify({
           error: 'Invalid type of filter value.',
         }));

--- a/backend/server.js
+++ b/backend/server.js
@@ -250,6 +250,7 @@ app.get('/search', wrap(async (req, res) => {
     }
     filters = JSON.parse(req.query.filters);
 
+    // Ensure filter key and value type are valid
     const validFilters = {
       NUpath: 'object',
       college: 'object',
@@ -258,7 +259,6 @@ app.get('/search', wrap(async (req, res) => {
       classType: 'string',
     }
     for (const [filterKey, filterValues] of Object.entries(filters)) {
-      // Ensure filters keys are valid
       if (!filterKey in validFilters) {
         macros.log(getTime(), 'Invalid filter key.', filterKey);
         res.send(JSON.stringify({
@@ -266,9 +266,8 @@ app.get('/search', wrap(async (req, res) => {
         }));
         return;
       }
-      // Ensure filter values are of the correct type
-      if (typeof filtersValues !== validFilters[filterKey]) {
-        macros.log(getTime(), `Invalid type of filter value ${typeof filtersValues} for ${filterKey}.`);
+      if (typeof filterValues !== validFilters[filterKey]) {
+        macros.log(getTime(), `Invalid type of filter value ${typeof filterValues} for ${filterKey}.`);
         res.send(JSON.stringify({
           error: 'Invalid type of filter value.',
         }));

--- a/backend/server.js
+++ b/backend/server.js
@@ -239,7 +239,42 @@ app.get('/search', wrap(async (req, res) => {
 
   let filters = {};
   if (req.query.filters) {
+
+    // Ensure filters is a string
+    if (typeof req.query.filters !== 'string') {
+      macros.log(getTime(), 'Invalid filters.', req.filters);
+      res.send(JSON.stringify({
+        error: 'Invalid filters.',
+      }));
+      return;
+    }
     filters = JSON.parse(req.query.filters);
+
+    const validFilters = {
+      NUpath: 'object',
+      college: 'object',
+      subject: 'object',
+      online: 'string',
+      classType: 'string',
+    }
+    for (const [filterKey, filterValues] of Object.entries(filters)) {
+      // Ensure filters keys are valid
+      if (!filterKey in validFilters) {
+        macros.log(getTime(), 'Invalid filter key.', filterKey);
+        res.send(JSON.stringify({
+          error: 'Invalid filter key.',
+        }));
+        return;
+      }
+      // Ensure filter values are of the correct type
+      if (typeof filtersValues !== validFilters[filterKey]) {
+        macros.log(getTime(), `Invalid type of filter value ${typeof filtersValues} for ${filterKey}.`);
+        res.send(JSON.stringify({
+          error: 'Invalid type of filter value.',
+        }));
+        return;
+      }
+    }
   }
 
   const { searchContent, took, resultCount } = await elastic.search(req.query.query, req.query.termId, req.query.minIndex, req.query.maxIndex, filters);

--- a/backend/server.js
+++ b/backend/server.js
@@ -238,9 +238,8 @@ app.get('/search', wrap(async (req, res) => {
   }
 
   let filters = {};
-  if (req.query.filter) {
-    // front end should encode filters as uri with encodeURIComponent(JSON.stringyfy(filters));
-    filters = JSON.parse(decodeURIComponent(filters));
+  if (req.query.filters) {
+    filters = JSON.parse(req.query.filters);
   }
 
   const { searchContent, took, resultCount } = await elastic.search(req.query.query, req.query.termId, req.query.minIndex, req.query.maxIndex, filters);

--- a/backend/server.js
+++ b/backend/server.js
@@ -256,21 +256,18 @@ app.get('/search', wrap(async (req, res) => {
       college: 'object',
       subject: 'object',
       online: 'string',
-      classType: 'string'
-    }
+      classType: 'string',
+    };
     for (const [filterKey, filterValues] of Object.entries(filters)) {
-
-      // Ensure filters keys are valid
-      if (!filterKey in validFilters) {
+      if (!(filterKey in validFilters)) {
         macros.log(getTime(), 'Invalid filter key.', filterKey);
         res.send(JSON.stringify({
           error: 'Invalid filter key.',
         }));
         return;
       }
-      // Ensure filter values are of the correct type
-      if (typeof filtersValues !== validFilters[filterKey]) {
-        macros.log(getTime(), `Invalid type of filter value ${typeof filtersValues} for ${filterKey}.`);
+      if (typeof filterValues !== validFilters[filterKey]) { // eslint-disable-line valid-typeof
+        macros.log(getTime(), `Invalid type of filter value ${typeof filterValues} for ${filterKey}.`);
         res.send(JSON.stringify({
           error: 'Invalid type of filter value.',
         }));

--- a/backend/server.js
+++ b/backend/server.js
@@ -237,7 +237,13 @@ app.get('/search', wrap(async (req, res) => {
     return;
   }
 
-  const { searchContent, took, resultCount } = await elastic.search(req.query.query, req.query.termId, req.query.minIndex, req.query.maxIndex);
+  let filters = {};
+  if (req.query.filter) {
+    // front end should encode filters as uri with encodeURIComponent(JSON.stringyfy(filters));
+    filters = JSON.parse(decodeURIComponent(filters));
+  }
+
+  const { searchContent, took, resultCount } = await elastic.search(req.query.query, req.query.termId, req.query.minIndex, req.query.maxIndex, filters);
   const midTime = Date.now();
 
   let string;

--- a/backend/server.js
+++ b/backend/server.js
@@ -249,24 +249,18 @@ app.get('/search', wrap(async (req, res) => {
     }
     filters = JSON.parse(req.query.filters);
 
-<<<<<<< HEAD
+
     // Ensure filter key and value type are valid
-=======
->>>>>>> check for valid filters in req
     const validFilters = {
       NUpath: 'object',
       college: 'object',
       subject: 'object',
       online: 'string',
-      classType: 'string',
-<<<<<<< HEAD
-    };
-    for (const [filterKey, filterValues] of Object.entries(filters)) {
-=======
+      classType: 'string'
     }
     for (const [filterKey, filterValues] of Object.entries(filters)) {
+
       // Ensure filters keys are valid
->>>>>>> check for valid filters in req
       if (!filterKey in validFilters) {
         macros.log(getTime(), 'Invalid filter key.', filterKey);
         res.send(JSON.stringify({
@@ -274,14 +268,9 @@ app.get('/search', wrap(async (req, res) => {
         }));
         return;
       }
-<<<<<<< HEAD
-      if (typeof filterValues !== validFilters[filterKey]) {
-        macros.log(getTime(), `Invalid type of filter value ${typeof filterValues} for ${filterKey}.`);
-=======
       // Ensure filter values are of the correct type
       if (typeof filtersValues !== validFilters[filterKey]) {
         macros.log(getTime(), `Invalid type of filter value ${typeof filtersValues} for ${filterKey}.`);
->>>>>>> check for valid filters in req
         res.send(JSON.stringify({
           error: 'Invalid type of filter value.',
         }));

--- a/frontend/components/tests/pages/__snapshots__/Home.test.js.snap
+++ b/frontend/components/tests/pages/__snapshots__/Home.test.js.snap
@@ -70,8 +70,7 @@ exports[`should render a section 1`] = `
             query=""
           />
         </div>
-        <TermDropdown
-          compact={false}
+        <Memo(TermDropdown)
           onChange={[Function]}
           termId="202030"
         />
@@ -106,7 +105,7 @@ exports[`should render a section 1`] = `
       </div>
     </div>
     <SplashPage />
-    <Footer />
+    <Memo(Footer) />
   </div>
 </div>
 `;

--- a/frontend/components/tests/pages/__snapshots__/Result.test.js.snap
+++ b/frontend/components/tests/pages/__snapshots__/Result.test.js.snap
@@ -3,7 +3,7 @@
 exports[`should render a section 1`] = `
 <Fragment>
   <div
-    className="Results_Header"
+    className="Results_Header Results_Header-top"
   >
     <img
       alt="logo"

--- a/frontend/components/tests/pages/__snapshots__/Result.test.js.snap
+++ b/frontend/components/tests/pages/__snapshots__/Result.test.js.snap
@@ -22,7 +22,7 @@ exports[`should render a section 1`] = `
         query="cs"
       />
     </div>
-    <TermDropdown
+    <Memo(TermDropdown)
       compact={true}
       onChange={[Function]}
       termId="202030"
@@ -33,13 +33,25 @@ exports[`should render a section 1`] = `
   >
     <div>
       <div
-        className="Results_Loading"
-      />
+        style={
+          Object {
+            "visibility": "hidden",
+          }
+        }
+      >
+        <div
+          className="subjectContaineRowContainer"
+        />
+        <ResultsLoader
+          loadMore={[Function]}
+          results={Array []}
+        />
+      </div>
     </div>
     <div
       className="botttomPadding"
     />
-    <Footer />
+    <Memo(Footer) />
   </div>
 </Fragment>
 `;

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -92,7 +92,7 @@ describe('elastic', () => {
     expect(elastic.validateFilters(invalidFilters)).toMatchObject({});
   });
 
-  it('keeps the valid filters', () => {
+  it('keeps all valid filters', () => {
     const validFilters = {
       NUpath: ['NU Core/NUpath Adv Writ Dscpl', 'NUpath Interpreting Culture'],
       college: ['UG Col Socl Sci & Humanities', 'GS Col of Arts', 'Computer&Info Sci'],

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -82,42 +82,42 @@ describe('elastic', () => {
 
   it('filter by one NUpath', async () => {
     const NUpath = 'NUpath Writing Intensive';
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { NUpath: [NUpath] }));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, { NUpath: [NUpath] })).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.classAttributes).toContain(NUpath));
   });
 
   it('filter by multiple NUpaths', async () => {
     const NUpaths = ['NUpath Difference/Diversity', 'NUpath Interpreting Culture'];
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { college: NUpaths }));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, { college: NUpaths })).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(_.intersection(result.class.classAttributes, NUpaths).length > 0).toBe(true));
   });
 
   it('filter by one college', async () => {
     const college = 'Computer&Info Sci';
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { college: [college] }));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, { college: [college] })).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.classAttributes).toContain(college));
   });
 
   it('filter by multiple colleges', async () => {
     const colleges = ['GS College of Science', 'GSBV Bouve'];
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { college: colleges }));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, { college: colleges })).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(_.intersection(result.class.classAttributes, colleges).length > 0).toBe(true));
   });
 
   it('filter by one subject', async () => {
     const subject = 'CS';
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { subject: [subject] }));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, { subject: [subject] })).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.subject).toBe(subject));
   });
 
   it('filter by multiple subjects', async () => {
     const subjects = ['CS', 'ENGL'];
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { subject: subjects }));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, { subject: subjects })).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(subjects).toContain(result.class.subject));
   });
@@ -131,20 +131,20 @@ describe('elastic', () => {
 
   it('filter for online: online option not selected', async () => {
     const onlineFilter = { online: false };
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, onlineFilter));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, onlineFilter)).searchContent;
     expect(allResults.length > 0).toBe(true);
   });
 
   it('filter for class type of seminar', async () => {
     const classTypeFilter = { classType: 'Seminar' };
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, classTypeFilter));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, classTypeFilter)).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.scheduleType).toBe(classTypeFilter.classType));
   });
 
   it('filter for class type of lab', async () => {
     const classTypeFilter = { classType: 'Lab' };
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, classTypeFilter));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, classTypeFilter)).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.scheduleType).toBe(classTypeFilter.classType));
   });
@@ -157,7 +157,7 @@ describe('elastic', () => {
       online: true,
       classType: 'Lecture',
     };
-    const allResults = getAllClassResult(await elastic.search('writing', '202010', 0, 5, filters));
+    const allResults = (await elastic.search('writing', '202010', 0, 5, filters)).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.classAttributes).toContain(filters.NUpath[0]));
     allResults.forEach(result => expect(result.class.classAttributes).toContain(filters.college[0]));
@@ -174,11 +174,7 @@ describe('elastic', () => {
       online: true,
       classType: 'Lecture',
     };
-<<<<<<< HEAD
     const allResults = (await elastic.search('science', '202010', 0, 2, filters)).searchContent;
-=======
-    const allResults = getAllClassResult(await elastic.search('science', '202010', 0, 2, filters));
->>>>>>> add tests
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(_.intersection(result.class.classAttributes, filters.NUpath).length > 0).toBe(true));
     allResults.forEach(result => expect(_.intersection(result.class.classAttributes, filters.college).length > 0).toBe(true));

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -1,81 +1,91 @@
 import elastic from '../backend/elastic';
 import Keys from '../common/Keys';
+import macros from '../backend/macros';
 
 function getFirstClassResult(results) {
-  return results.searchContent[0]["class"];
+  return results.searchContent[0].class;
+}
+
+function getAllClassResult(results) {
+  return results.searchContent;
 }
 
 describe('elastic', () => {
   it('returns specified class with class code query', async () => {
-    let firstResult = getFirstClassResult(await elastic.search('cs2500', '202010', 0, 1));
+    const firstResult = getFirstClassResult(await elastic.search('cs2500', '202010', 0, 1));
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
   it('returns specified class with name query', async () => {
-    let firstResult = getFirstClassResult(await elastic.search('fundamentals of computer science 2', '202010', 0, 1));
+    const firstResult = getFirstClassResult(await elastic.search('fundamentals of computer science 2', '202010', 0, 1));
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2510');
   });
 
   it('returns a professor if name requested', async () => {
-    let results = await elastic.search('mislove', '202010', 0, 1);
-    let firstResult = results.searchContent[0]['employee'];
+    const results = await elastic.search('mislove', '202010', 0, 1);
+    const firstResult = results.searchContent[0].employee;
     expect(firstResult.emails).toContain('a.mislove@northeastern.edu');
   });
 
   it('returns a professor if email requested', async () => {
-    let results = await elastic.search('a.mislove@northeastern.edu', '202010', 0, 1);
-    let firstResult = results.searchContent[0]['employee'];
+    const results = await elastic.search('a.mislove@northeastern.edu', '202010', 0, 1);
+    const firstResult = results.searchContent[0].employee;
     expect(firstResult.emails).toContain('a.mislove@northeastern.edu');
   });
 
   it('returns a professor if phone requested', async () => {
-    let results = await elastic.search('6173737069', '202010', 0, 1);
-    let firstResult = results.searchContent[0]['employee'];
+    const results = await elastic.search('6173737069', '202010', 0, 1);
+    const firstResult = results.searchContent[0].employee;
     expect(firstResult.emails).toContain('a.mislove@northeastern.edu');
   });
 
   it('does not place labs and recitations as top results', async () => {
-    let firstResult = getFirstClassResult(await elastic.search('cs', '202010', 0, 1));
+    const firstResult = getFirstClassResult(await elastic.search('cs', '202010', 0, 1));
     expect(['Lab', 'Recitation & Discussion', 'Seminar']).not.toContain(firstResult.scheduleType);
   });
 
   it('aliases class names', async () => {
-    let firstResult = getFirstClassResult(await elastic.search('fundies', '202010', 0, 1));
+    const firstResult = getFirstClassResult(await elastic.search('fundies', '202010', 0, 1));
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
-  [['cs', '2500'], ['cs', '2501'], ['thtr', '1000']].forEach((item, index, array) => {
+  [['cs', '2500'], ['cs', '2501'], ['thtr', '1000']].forEach((item) => {
     it(`always analyzes course code  ${item.join(' ')} the same way regardless of string`, async () => {
-      let canonicalResult = getFirstClassResult(await elastic.search(item.join(' '), '202010', 0, 1));
+      const canonicalResult = getFirstClassResult(await elastic.search(item.join(' '), '202010', 0, 1));
 
-      let firstResult = getFirstClassResult(await elastic.search(item.join(''), '202010', 0, 1));
+      const firstResult = getFirstClassResult(await elastic.search(item.join(''), '202010', 0, 1));
       expect(Keys.getClassHash(firstResult)).toBe(Keys.getClassHash(canonicalResult));
- 
-      let secondResult = getFirstClassResult(await elastic.search(item.join(' ').toUpperCase(), '202010', 0, 1));
+
+      const secondResult = getFirstClassResult(await elastic.search(item.join(' ').toUpperCase(), '202010', 0, 1));
       expect(Keys.getClassHash(secondResult)).toBe(Keys.getClassHash(canonicalResult));
 
-      let thirdResult = getFirstClassResult(await elastic.search(item.join('').toUpperCase(), '202010', 0, 1));
+      const thirdResult = getFirstClassResult(await elastic.search(item.join('').toUpperCase(), '202010', 0, 1));
       expect(Keys.getClassHash(thirdResult)).toBe(Keys.getClassHash(canonicalResult));
     });
   });
 
   it('returns search results of same subject if course code query', async () => {
-    let results = await elastic.search('cs2500', '202010', 0, 10);
-    results.searchContent.map(result => expect(result["class"].subject).toBe('CS'));
+    const results = await elastic.search('cs2500', '202010', 0, 10);
+    results.searchContent.map((result) => { return expect(result.class.subject).toBe('CS'); });
   });
 
   it('autocorrects typos', async () => {
-    let firstResult = getFirstClassResult(await elastic.search('fundimentals of compiter science', '202010', 0, 1)); 
+    const firstResult = getFirstClassResult(await elastic.search('fundimentals of compiter science', '202010', 0, 1));
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
   it('does not return default results', async () => {
-    let results = await elastic.search('', '202010', 0, 10);
+    const results = await elastic.search('', '202010', 0, 10);
     expect(results.searchContent.length).toBe(0);
   });
 
   it('fetches correct result if query is a crn', async () => {
-    let firstResult = getFirstClassResult(await elastic.search('10460', '202010', 0, 1));
+    const firstResult = getFirstClassResult(await elastic.search('10460', '202010', 0, 1));
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
+  });
+
+  it('filter by college', async () => {
+    const allResults = getAllClassResult(await elastic.search('math', '202010', 0, 1, { college: 'Computer&Info Sci' }));
+    allResults.forEach(result => expect(result.class.classAttributes).toContain('Computer&Info Sci'));
   });
 });

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -6,10 +6,6 @@ function getFirstClassResult(results) {
   return results.searchContent[0].class;
 }
 
-function getAllClassResult(results) {
-  return results.searchContent;
-}
-
 describe('elastic', () => {
   it('returns specified class with class code query', async () => {
     const firstResult = getFirstClassResult(await elastic.search('cs2500', '202010', 0, 1));
@@ -86,69 +82,69 @@ describe('elastic', () => {
 
   it('filter by one NUpath', async () => {
     const NUpath = 'NUpath Writing Intensive';
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { NUpath: [NUpath] }));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, { NUpath: [NUpath] })).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.classAttributes).toContain(NUpath));
   });
 
   it('filter by multiple NUpaths', async () => {
     const NUpaths = ['NUpath Difference/Diversity', 'NUpath Interpreting Culture'];
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { college: NUpaths }));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, { college: NUpaths })).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(_.intersection(result.class.classAttributes, NUpaths).length > 0).toBe(true));
   });
 
   it('filter by one college', async () => {
     const college = 'Computer&Info Sci';
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { college: [college] }));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, { college: [college] })).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.classAttributes).toContain(college));
   });
 
   it('filter by multiple colleges', async () => {
     const colleges = ['GS College of Science', 'GSBV Bouve'];
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { college: colleges }));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, { college: colleges })).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(_.intersection(result.class.classAttributes, colleges).length > 0).toBe(true));
   });
 
   it('filter by one subject', async () => {
     const subject = 'CS';
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { subject: [subject] }));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, { subject: [subject] })).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.subject).toBe(subject));
   });
 
   it('filter by multiple subjects', async () => {
     const subjects = ['CS', 'ENGL'];
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { subject: subjects }));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, { subject: subjects })).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(subjects).toContain(result.class.subject));
   });
 
   it('filter for online: if any section is online', async () => {
     const onlineFilter = { online: true };
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, onlineFilter));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, onlineFilter)).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.sections.map(section => section.online)).toContain(true));
   });
 
   it('filter for online: online option not selected', async () => {
     const onlineFilter = { online: false };
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, onlineFilter));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, onlineFilter)).searchContent;
     expect(allResults.length > 0).toBe(true);
   });
 
   it('filter for class type of seminar', async () => {
     const classTypeFilter = { classType: 'Seminar' };
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, classTypeFilter));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, classTypeFilter)).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.scheduleType).toBe(classTypeFilter.classType));
   });
 
   it('filter for class type of lab', async () => {
     const classTypeFilter = { classType: 'Lab' };
-    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, classTypeFilter));
+    const allResults = (await elastic.search('2500', '202010', 0, 20, classTypeFilter)).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.scheduleType).toBe(classTypeFilter.classType));
   });
@@ -161,7 +157,7 @@ describe('elastic', () => {
       online: true,
       classType: 'Lecture',
     };
-    const allResults = getAllClassResult(await elastic.search('writing', '202010', 0, 5, filters));
+    const allResults = (await elastic.search('writing', '202010', 0, 5, filters)).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.classAttributes).toContain(filters.NUpath[0]));
     allResults.forEach(result => expect(result.class.classAttributes).toContain(filters.college[0]));
@@ -178,7 +174,7 @@ describe('elastic', () => {
       online: true,
       classType: 'Lecture',
     };
-    const allResults = getAllClassResult(await elastic.search('science', '202010', 0, 2, filters));
+    const allResults = (await elastic.search('science', '202010', 0, 2, filters)).searchContent;
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(_.intersection(result.class.classAttributes, filters.NUpath).length > 0).toBe(true));
     allResults.forEach(result => expect(_.intersection(result.class.classAttributes, filters.college).length > 0).toBe(true));

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -84,8 +84,6 @@ describe('elastic', () => {
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
-  // Tests for filters below
-
   it('filter by one NUpath', async () => {
     const NUpath = 'NUpath Writing Intensive';
     const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { NUpath: [NUpath] }));

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -84,8 +84,13 @@ describe('elastic', () => {
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
-  it('filter by college', async () => {
-    const allResults = getAllClassResult(await elastic.search('math', '202010', 0, 1, { college: 'Computer&Info Sci' }));
+  it('filter by one college', async () => {
+    const allResults = getAllClassResult(await elastic.search('course', '202010', 0, 100, { college: ['Computer&Info Sci'] }));
+    allResults.forEach(result => expect(result.class.classAttributes).toContain('Computer&Info Sci'));
+  });
+
+  it('filter by multiple colleges', async () => {
+    const allResults = getAllClassResult(await elastic.search('course', '202010', 0, 100, { college: ['Computer&Info Sci'] }));
     allResults.forEach(result => expect(result.class.classAttributes).toContain('Computer&Info Sci'));
   });
 });

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -84,6 +84,8 @@ describe('elastic', () => {
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
+  // Tests for filters below
+
   it('filter by one NUpath', async () => {
     const NUpath = 'NUpath Writing Intensive';
     const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { NUpath: [NUpath] }));

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -84,15 +84,22 @@ describe('elastic', () => {
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
-  it('filter by one college', async () => {
-    const college = 'Computer&Info Sci';
-    const allResults = getAllClassResult(await elastic.search('course', '202010', 0, 20, { college: [college] }));
-    allResults.forEach(result => expect(result.class.classAttributes).toContain(college));
+  it('filter for online: if any section is online', async () => {
+    const onlineFilter = { online: true };
+    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, onlineFilter));
+    expect(allResults.length > 0).toBe(true);
+    allResults.forEach(result => expect(result.sections.map(section => section.online)).toContain(true));
   });
 
-  it('filter by multiple colleges', async () => {
-    const colleges = ['GS College of Science', 'GSBV Bouve'];
-    const allResults = getAllClassResult(await elastic.search('course', '202010', 0, 20, { college: colleges }));
-    allResults.forEach(result => expect(_.intersection(result.class.classAttributes, colleges).length > 0).toBe(true));
-  });
+  // it('filter by one college', async () => {
+  //   const college = 'Computer&Info Sci';
+  //   const allResults = getAllClassResult(await elastic.search('course', '202010', 0, 20, { college: [college] }));
+  //   allResults.forEach(result => expect(result.class.classAttributes).toContain(college));
+  // });
+
+  // it('filter by multiple colleges', async () => {
+  //   const colleges = ['GS College of Science', 'GSBV Bouve'];
+  //   const allResults = getAllClassResult(await elastic.search('course', '202010', 0, 20, { college: colleges }));
+  //   allResults.forEach(result => expect(_.intersection(result.class.classAttributes, colleges).length > 0).toBe(true));
+  // });
 });

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -80,6 +80,8 @@ describe('elastic', () => {
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
+  // Tests for filters below
+
   it('filter by one NUpath', async () => {
     const NUpath = 'NUpath Writing Intensive';
     const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { NUpath: [NUpath] }));

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -81,7 +81,7 @@ describe('elastic', () => {
   });
 
   it('convertes filters to es class filters', () => {
-    const termId = '202010'
+    const termId = '202010';
     const filters = {
       NUpath: ['NU Core/NUpath Adv Writ Dscpl', 'NUpath Interpreting Culture'],
       college: ['UG Col Socl Sci & Humanities', 'GS Col of Arts', 'Computer&Info Sci'],

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import elastic from '../backend/elastic';
 import Keys from '../common/Keys';
-import macros from '../backend/macros';
 
 function getFirstClassResult(results) {
   return results.searchContent[0].class;

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -80,7 +80,7 @@ describe('elastic', () => {
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
-  it('convertes filters to es class filters', () => {
+  it('converts filters to es class filters', () => {
     const termId = '202010';
     const filters = {
       NUpath: ['NU Core/NUpath Adv Writ Dscpl', 'NUpath Interpreting Culture'],

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -84,6 +84,8 @@ describe('elastic', () => {
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
+  // test NUpath, college, subject, online, classType
+
   it('filter for online: if any section is online', async () => {
     const onlineFilter = { online: true };
     const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, onlineFilter));

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -80,7 +80,47 @@ describe('elastic', () => {
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
-  // test NUpath, college, subject, online, classType
+  it('filter by one NUpath', async () => {
+    const NUpath = 'NUpath Writing Intensive';
+    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { NUpath: [NUpath] }));
+    expect(allResults.length > 0).toBe(true);
+    allResults.forEach(result => expect(result.class.classAttributes).toContain(NUpath));
+  });
+
+  it('filter by multiple NUpaths', async () => {
+    const NUpaths = ['NUpath Difference/Diversity', 'NUpath Interpreting Culture'];
+    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { college: NUpaths }));
+    expect(allResults.length > 0).toBe(true);
+    allResults.forEach(result => expect(_.intersection(result.class.classAttributes, NUpaths).length > 0).toBe(true));
+  });
+
+  it('filter by one college', async () => {
+    const college = 'Computer&Info Sci';
+    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { college: [college] }));
+    expect(allResults.length > 0).toBe(true);
+    allResults.forEach(result => expect(result.class.classAttributes).toContain(college));
+  });
+
+  it('filter by multiple colleges', async () => {
+    const colleges = ['GS College of Science', 'GSBV Bouve'];
+    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { college: colleges }));
+    expect(allResults.length > 0).toBe(true);
+    allResults.forEach(result => expect(_.intersection(result.class.classAttributes, colleges).length > 0).toBe(true));
+  });
+
+  it('filter by one subject', async () => {
+    const subject = 'CS';
+    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { subject: [subject] }));
+    expect(allResults.length > 0).toBe(true);
+    allResults.forEach(result => expect(result.class.subject).toBe(subject));
+  });
+
+  it('filter by multiple subjects', async () => {
+    const subjects = ['CS', 'ENGL'];
+    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { subject: subjects }));
+    expect(allResults.length > 0).toBe(true);
+    allResults.forEach(result => expect(subjects).toContain(result.class.subject));
+  });
 
   it('filter for online: if any section is online', async () => {
     const onlineFilter = { online: true };
@@ -91,20 +131,20 @@ describe('elastic', () => {
 
   it('filter for online: online option not selected', async () => {
     const onlineFilter = { online: false };
-    const allResults = (await elastic.search('2500', '202010', 0, 20, onlineFilter)).searchContent;
+    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, onlineFilter));
     expect(allResults.length > 0).toBe(true);
   });
 
   it('filter for class type of seminar', async () => {
     const classTypeFilter = { classType: 'Seminar' };
-    const allResults = (await elastic.search('2500', '202010', 0, 20, classTypeFilter)).searchContent;
+    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, classTypeFilter));
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.scheduleType).toBe(classTypeFilter.classType));
   });
 
   it('filter for class type of lab', async () => {
     const classTypeFilter = { classType: 'Lab' };
-    const allResults = (await elastic.search('2500', '202010', 0, 20, classTypeFilter)).searchContent;
+    const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, classTypeFilter));
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.scheduleType).toBe(classTypeFilter.classType));
   });
@@ -117,7 +157,7 @@ describe('elastic', () => {
       online: true,
       classType: 'Lecture',
     };
-    const allResults = (await elastic.search('writing', '202010', 0, 5, filters)).searchContent;
+    const allResults = getAllClassResult(await elastic.search('writing', '202010', 0, 5, filters));
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(result.class.classAttributes).toContain(filters.NUpath[0]));
     allResults.forEach(result => expect(result.class.classAttributes).toContain(filters.college[0]));
@@ -134,7 +174,11 @@ describe('elastic', () => {
       online: true,
       classType: 'Lecture',
     };
+<<<<<<< HEAD
     const allResults = (await elastic.search('science', '202010', 0, 2, filters)).searchContent;
+=======
+    const allResults = getAllClassResult(await elastic.search('science', '202010', 0, 2, filters));
+>>>>>>> add tests
     expect(allResults.length > 0).toBe(true);
     allResults.forEach(result => expect(_.intersection(result.class.classAttributes, filters.NUpath).length > 0).toBe(true));
     allResults.forEach(result => expect(_.intersection(result.class.classAttributes, filters.college).length > 0).toBe(true));

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -1,6 +1,6 @@
+import _ from 'lodash';
 import elastic from '../backend/elastic';
 import Keys from '../common/Keys';
-import macros from '../backend/macros';
 
 function getFirstClassResult(results) {
   return results.searchContent[0].class;
@@ -85,12 +85,14 @@ describe('elastic', () => {
   });
 
   it('filter by one college', async () => {
-    const allResults = getAllClassResult(await elastic.search('course', '202010', 0, 100, { college: ['Computer&Info Sci'] }));
-    allResults.forEach(result => expect(result.class.classAttributes).toContain('Computer&Info Sci'));
+    const college = 'Computer&Info Sci';
+    const allResults = getAllClassResult(await elastic.search('course', '202010', 0, 20, { college: [college] }));
+    allResults.forEach(result => expect(result.class.classAttributes).toContain(college));
   });
 
   it('filter by multiple colleges', async () => {
-    const allResults = getAllClassResult(await elastic.search('course', '202010', 0, 100, { college: ['Computer&Info Sci'] }));
-    allResults.forEach(result => expect(result.class.classAttributes).toContain('Computer&Info Sci'));
+    const colleges = ['GS College of Science', 'GSBV Bouve'];
+    const allResults = getAllClassResult(await elastic.search('course', '202010', 0, 20, { college: colleges }));
+    allResults.forEach(result => expect(_.intersection(result.class.classAttributes, colleges).length > 0).toBe(true));
   });
 });

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import elastic from '../backend/elastic';
 import Keys from '../common/Keys';
+import macros from '../backend/macros';
 
 function getFirstClassResult(results) {
   return results.searchContent[0].class;

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -80,8 +80,6 @@ describe('elastic', () => {
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
-  // Tests for filters below
-
   it('filter by one NUpath', async () => {
     const NUpath = 'NUpath Writing Intensive';
     const allResults = getAllClassResult(await elastic.search('2500', '202010', 0, 20, { NUpath: [NUpath] }));

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -80,68 +80,7 @@ describe('elastic', () => {
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
-  it('converts filters to es class filters', () => {
-    const termId = '202010';
-    const filters = {
-      NUpath: ['NU Core/NUpath Adv Writ Dscpl', 'NUpath Interpreting Culture'],
-      college: ['UG Col Socl Sci & Humanities', 'GS Col of Arts', 'Computer&Info Sci'],
-      subject: ['ENGW', 'ARTG', 'CS'],
-      online: true,
-      classType: 'Lecture',
-    };
-    const esFilters = elastic.getClassFilterQuery(termId, filters);
-    const expectedEsFilters = [{"exists": {"field": "sections"}}, {"term": {"class.termId": "202010"}}, 
-    {"bool": {"should": [{"match_phrase": {"class.classAttributes": "NU Core/NUpath Adv Writ Dscpl"}}, 
-    {"match_phrase": {"class.classAttributes": "NUpath Interpreting Culture"}}]}}, 
-    {"bool": {"should": [{"match_phrase": {"class.classAttributes": "UG Col Socl Sci & Humanities"}}, 
-    {"match_phrase": {"class.classAttributes": "GS Col of Arts"}}, 
-    {"match_phrase": {"class.classAttributes": "Computer&Info Sci"}}]}}, 
-    {"bool": {"should": [{"match": {"class.subject": "ENGW"}}, {"match": {"class.subject": "ARTG"}}, {"match": {"class.subject": "CS"}}]}}, 
-    {"term": {"sections.online": true}}, {"match": {"class.scheduleType": "Lecture"}}]
-    expect(esFilters).toMatchObject(expectedEsFilters);
-  })
-
-  it('filter by one NUpath', async () => {
-    const NUpath = 'NUpath Writing Intensive';
-    const allResults = (await elastic.search('2500', '202010', 0, 20, { NUpath: [NUpath] })).searchContent;
-    expect(allResults.length > 0).toBe(true);
-    allResults.forEach(result => expect(result.class.classAttributes).toContain(NUpath));
-  });
-
-  it('filter by multiple NUpaths', async () => {
-    const NUpaths = ['NUpath Difference/Diversity', 'NUpath Interpreting Culture'];
-    const allResults = (await elastic.search('2500', '202010', 0, 20, { college: NUpaths })).searchContent;
-    expect(allResults.length > 0).toBe(true);
-    allResults.forEach(result => expect(_.intersection(result.class.classAttributes, NUpaths).length > 0).toBe(true));
-  });
-
-  it('filter by one college', async () => {
-    const college = 'Computer&Info Sci';
-    const allResults = (await elastic.search('2500', '202010', 0, 20, { college: [college] })).searchContent;
-    expect(allResults.length > 0).toBe(true);
-    allResults.forEach(result => expect(result.class.classAttributes).toContain(college));
-  });
-
-  it('filter by multiple colleges', async () => {
-    const colleges = ['GS College of Science', 'GSBV Bouve'];
-    const allResults = (await elastic.search('2500', '202010', 0, 20, { college: colleges })).searchContent;
-    expect(allResults.length > 0).toBe(true);
-    allResults.forEach(result => expect(_.intersection(result.class.classAttributes, colleges).length > 0).toBe(true));
-  });
-
-  it('filter by one subject', async () => {
-    const subject = 'CS';
-    const allResults = (await elastic.search('2500', '202010', 0, 20, { subject: [subject] })).searchContent;
-    expect(allResults.length > 0).toBe(true);
-    allResults.forEach(result => expect(result.class.subject).toBe(subject));
-  });
-
-  it('filter by multiple subjects', async () => {
-    const subjects = ['CS', 'ENGL'];
-    const allResults = (await elastic.search('2500', '202010', 0, 20, { subject: subjects })).searchContent;
-    expect(allResults.length > 0).toBe(true);
-    allResults.forEach(result => expect(subjects).toContain(result.class.subject));
-  });
+  // test NUpath, college, subject, online, classType
 
   it('filter for online: if any section is online', async () => {
     const onlineFilter = { online: true };


### PR DESCRIPTION
This is the backend setup for the following filters:
- NUpath
- college 
- subject
- online
- classType

Main update is converting a json of filters, e.g.`{
      'NUpath': ['NU Core/NUpath Adv Writ Dscpl', 'NUpath Interpreting Culture'],
      'college': ['UG Col Socl Sci & Humanities', 'GS Col of Arts', 'Computer&Info Sci'],
      'subject': ['ENGW', 'ARTG', 'CS'],
      'online': true,
      'classType': 'Lecture'
    }` into an elasticsearch query.

Need feedback on the following issues:
- [x] Is there a better way of constructing the es compound query (`terms`, `function_score` etc.)?
- [x] Should we disable employee search when any class filter is on?
- [x] Should we allow empty search query now?