### PR TITLE
display TBA w mt prof

### DIFF
--- a/frontend/components/classModels/Section.js
+++ b/frontend/components/classModels/Section.js
@@ -104,7 +104,7 @@ class Section {
 
   // Unique list of all professors in all meetings, sorted alphabetically
   getProfs() {
-    return Array.from(this.profs).sort();
+    return this.profs.length > 0 ? Array.from(this.profs).sort() : ['TBA'];
   }
 
   getLocations(ignoreExams = true) {


### PR DESCRIPTION
When a course does not yet have an affiliated professor, the professor field should say 'TBA' instead of being empty.