### PR TITLE
Improve Dropdown Interaction

### DIFF
--- a/frontend/components/ResultsPage/DropdownFilter.tsx
+++ b/frontend/components/ResultsPage/DropdownFilter.tsx
@@ -16,23 +16,34 @@ export default function DropdownFilter({
   title, options, selected, setActive,
 }: DropdownFilter) {
   const [filterString, setFilterString] = useState('');
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(false);
 
   const dropdown = useRef(null);
 
   useClickOutside(dropdown, isOpen, setIsOpen);
 
   function handleClickOnTheDropdown() {
-    setIsOpen(!isOpen);
+    if (selected.length != 0 || filteredOptions.length != 0) {
+      setIsOpen(!isOpen);
+    }
   }
 
+  function handleClickOnDropdownSearch(e) {
+    e.stopPropagation();
+    if (!isOpen) {
+      setIsOpen(true);
+    }
+  }
+
+  const filteredOptions = options.filter((option) => option.value.toUpperCase().includes(filterString.toUpperCase()) && !selected.includes(option.value));
+
   return (
-    <div className='DropdownFilter'>
+    <div className= 'DropdownFilter'>
       <div className='DropdownFilter__title'>{title}</div>
       <div className='DropdownFilter__dropdown' ref={ dropdown } role='button' tabIndex={ 0 } onClick={ handleClickOnTheDropdown }>
-        <div className={ `DropdownFilter__search ${isOpen ? 'expanded' : ''}` }>
+        <div className={ `DropdownFilter__search ${selected.length === 0 && filteredOptions.length === 0 ? 'disabled' : isOpen ? 'expanded' : ''}` }>
           {selected.map((selectElement) => (
-            <span className='DropdownFilter__inputElement'>
+            <span className='DropdownFilter__inputElement' onClick={ (e) => e.stopPropagation() }>
               { selectElement }
               <img
                 src={ pillClose }
@@ -43,17 +54,28 @@ export default function DropdownFilter({
             </span>
           ))}
           <input
-            className='DropdownFilter__input'
+            className={ `DropdownFilter__input ${selected.length === 0 && filteredOptions.length === 0 ? 'disabled' : ''}` }
             tabIndex={ 0 }
             type='text'
             value={ filterString }
-            placeholder={ selected.length === 0 ? 'Choose one or multiple' : '' }
+            placeholder={ selected.length === 0 ? (filteredOptions.length > 0 ? 'Choose one or multiple' : 'No filters apply') : '' }
             onChange={ (event) => setFilterString(event.target.value) }
+            onClick={ (e) => { e.stopPropagation(); if (selected.length != 0 || filteredOptions.length != 0) {setIsOpen(true);} } }
           />
-          <img src={ dropdownArrow } alt='Dropdown arrow' className='DropdownFilter__icon' />
+          <img src={ dropdownArrow } alt='Dropdown arrow' className={ `DropdownFilter__icon ${selected.length === 0 && filteredOptions.length === 0 ? 'disabled' : isOpen ? 'rotated' : ''}` } />
         </div>
         <div className='DropdownFilter__selectable'>
-          {isOpen && options.filter((option) => option.value.toUpperCase().includes(filterString.toUpperCase()) && !selected.includes(option.value)).map((option) => (
+          {isOpen && (filteredOptions.length === 0 ?
+            <div
+              role='option'
+              aria-selected='true'
+              aria-checked='false'
+              className='DropdownFilter__noResults'
+              onClick={ (e) => e.stopPropagation() }
+            >
+              <span className='DropdownFilter__elementText'>{"No results found."}</span>
+            </div> :
+            filteredOptions.map((option) => (
             <div
               role='option'
               tabIndex={ -1 }
@@ -61,12 +83,14 @@ export default function DropdownFilter({
               aria-checked='false'
               className='DropdownFilter__element'
               key={ option.value }
-              onClick={ () => { setActive(selected.includes(option.value) ? pull(selected, option.value) : [...selected, option.value]) } }
+              onClick={ (e) => { setActive(selected.includes(option.value) ? pull(selected, option.value) : [...selected, option.value]);
+              setFilterString('');
+              e.stopPropagation(); } }
             >
               <span className='DropdownFilter__elementText'>{option.value}</span>
               <span className='DropdownFilter__elementCount'>({option.count})</span>
             </div>
-          ))}
+          )))}
         </div>
       </div>
     </div>

--- a/frontend/components/ResultsPage/DropdownFilter.tsx
+++ b/frontend/components/ResultsPage/DropdownFilter.tsx
@@ -84,7 +84,7 @@ export default function DropdownFilter({
                 tabIndex={ 0 }
                 aria-selected='true'
                 aria-checked='false'
-                className='DropdownFilter__noResults'
+                className='DropdownFilter--noResults'
                 onClick={ (e) => e.stopPropagation() }
               >
                 <span className='DropdownFilter__elementText'>No results found.</span>

--- a/frontend/components/ResultsPage/DropdownFilter.tsx
+++ b/frontend/components/ResultsPage/DropdownFilter.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { without } from 'lodash';
+import { without, pull } from 'lodash';
 import { Option } from './filters';
 import useClickOutside from './useClickOutside';
 import '../../css/_DropdownFilter.scss';
@@ -20,30 +20,42 @@ export default function DropdownFilter({
 
   const dropdown = useRef(null);
 
+  const filteredOptions = options.filter((option) => option.value.toUpperCase().includes(filterString.toUpperCase()) && !selected.includes(option.value));
+
   useClickOutside(dropdown, isOpen, setIsOpen);
 
   function handleClickOnTheDropdown() {
-    if (selected.length != 0 || filteredOptions.length != 0) {
+    if (selected.length !== 0 || filteredOptions.length !== 0) {
       setIsOpen(!isOpen);
     }
   }
 
-  function handleClickOnDropdownSearch(e) {
-    e.stopPropagation();
-    if (!isOpen) {
-      setIsOpen(true);
+  function getDropdownStatus() {
+    if (selected.length === 0 && filteredOptions.length === 0) {
+      return 'disabled';
+    } if (isOpen) {
+      return 'expanded';
     }
+    return '';
   }
 
-  const filteredOptions = options.filter((option) => option.value.toUpperCase().includes(filterString.toUpperCase()) && !selected.includes(option.value));
+  function choosePlaceholder() {
+    if (selected.length === 0) {
+      if (filteredOptions.length > 0) {
+        return 'Choose one or multiple';
+      }
+      return 'No filters apply';
+    }
+    return '';
+  }
 
   return (
-    <div className= 'DropdownFilter'>
+    <div className='DropdownFilter'>
       <div className='DropdownFilter__title'>{title}</div>
       <div className='DropdownFilter__dropdown' ref={ dropdown } role='button' tabIndex={ 0 } onClick={ handleClickOnTheDropdown }>
-        <div className={ `DropdownFilter__search ${selected.length === 0 && filteredOptions.length === 0 ? 'disabled' : isOpen ? 'expanded' : ''}` }>
+        <div className={ `DropdownFilter__search ${getDropdownStatus()}` }>
           {selected.map((selectElement) => (
-            <span className='DropdownFilter__inputElement' onClick={ (e) => e.stopPropagation() }>
+            <span className='DropdownFilter__inputElement' role='button' tabIndex={ 0 } onClick={ (e) => e.stopPropagation() }>
               { selectElement }
               <img
                 src={ pillClose }
@@ -58,39 +70,44 @@ export default function DropdownFilter({
             tabIndex={ 0 }
             type='text'
             value={ filterString }
-            placeholder={ selected.length === 0 ? (filteredOptions.length > 0 ? 'Choose one or multiple' : 'No filters apply') : '' }
+            placeholder={ choosePlaceholder() }
             onChange={ (event) => setFilterString(event.target.value) }
-            onClick={ (e) => { e.stopPropagation(); if (selected.length != 0 || filteredOptions.length != 0) {setIsOpen(true);} } }
+            onClick={ (e) => { e.stopPropagation(); if (selected.length !== 0 || filteredOptions.length !== 0) { setIsOpen(true); } } }
           />
-          <img src={ dropdownArrow } alt='Dropdown arrow' className={ `DropdownFilter__icon ${selected.length === 0 && filteredOptions.length === 0 ? 'disabled' : isOpen ? 'rotated' : ''}` } />
+          <img src={ dropdownArrow } alt='Dropdown arrow' className={ `DropdownFilter__icon ${getDropdownStatus()}` } />
         </div>
         <div className='DropdownFilter__selectable'>
-          {isOpen && (filteredOptions.length === 0 ?
-            <div
-              role='option'
-              aria-selected='true'
-              aria-checked='false'
-              className='DropdownFilter__noResults'
-              onClick={ (e) => e.stopPropagation() }
-            >
-              <span className='DropdownFilter__elementText'>{"No results found."}</span>
-            </div> :
-            filteredOptions.map((option) => (
-            <div
-              role='option'
-              tabIndex={ -1 }
-              aria-selected='true'
-              aria-checked='false'
-              className='DropdownFilter__element'
-              key={ option.value }
-              onClick={ (e) => { setActive(selected.includes(option.value) ? pull(selected, option.value) : [...selected, option.value]);
-              setFilterString('');
-              e.stopPropagation(); } }
-            >
-              <span className='DropdownFilter__elementText'>{option.value}</span>
-              <span className='DropdownFilter__elementCount'>({option.count})</span>
-            </div>
-          )))}
+          {isOpen && (filteredOptions.length === 0
+            ? (
+              <div
+                role='option'
+                tabIndex={ 0 }
+                aria-selected='true'
+                aria-checked='false'
+                className='DropdownFilter__noResults'
+                onClick={ (e) => e.stopPropagation() }
+              >
+                <span className='DropdownFilter__elementText'>No results found.</span>
+              </div>
+            )
+            : filteredOptions.map((option) => (
+              <div
+                role='option'
+                tabIndex={ -1 }
+                aria-selected='true'
+                aria-checked='false'
+                className='DropdownFilter__element'
+                key={ option.value }
+                onClick={ (e) => {
+                  setActive(selected.includes(option.value) ? pull(selected, option.value) : [...selected, option.value]);
+                  setFilterString('');
+                  e.stopPropagation();
+                } }
+              >
+                <span className='DropdownFilter__elementText'>{option.value}</span>
+                <span className='DropdownFilter__elementCount'>({option.count})</span>
+              </div>
+            )))}
         </div>
       </div>
     </div>

--- a/frontend/components/ResultsPage/DropdownFilter.tsx
+++ b/frontend/components/ResultsPage/DropdownFilter.tsx
@@ -66,7 +66,7 @@ export default function DropdownFilter({
             </span>
           ))}
           <input
-            className={ `DropdownFilter__input ${selected.length === 0 && filteredOptions.length === 0 && !isOpen? 'disabled' : ''}` }
+            className={ `DropdownFilter__input ${selected.length === 0 && filteredOptions.length === 0 && !isOpen ? 'disabled' : ''}` }
             tabIndex={ 0 }
             type='text'
             value={ filterString }

--- a/frontend/components/ResultsPage/DropdownFilter.tsx
+++ b/frontend/components/ResultsPage/DropdownFilter.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { pull } from 'lodash';
+import { without } from 'lodash';
 import { Option } from './filters';
 import useClickOutside from './useClickOutside';
 import '../../css/_DropdownFilter.scss';
@@ -49,7 +49,7 @@ export default function DropdownFilter({
                 src={ pillClose }
                 className='DropdownFilter__inputDelete'
                 alt='X to remove pill'
-                onClick={ () => setActive(pull(selected, selectElement)) }
+                onClick={ () => setActive(without(selected, selectElement)) }
               />
             </span>
           ))}

--- a/frontend/components/ResultsPage/DropdownFilter.tsx
+++ b/frontend/components/ResultsPage/DropdownFilter.tsx
@@ -31,7 +31,7 @@ export default function DropdownFilter({
   }
 
   function getDropdownStatus() {
-    if (selected.length === 0 && filteredOptions.length === 0) {
+    if (selected.length === 0 && filteredOptions.length === 0 && !isOpen) {
       return 'disabled';
     } if (isOpen) {
       return 'expanded';
@@ -66,7 +66,7 @@ export default function DropdownFilter({
             </span>
           ))}
           <input
-            className={ `DropdownFilter__input ${selected.length === 0 && filteredOptions.length === 0 ? 'disabled' : ''}` }
+            className={ `DropdownFilter__input ${selected.length === 0 && filteredOptions.length === 0 && !isOpen? 'disabled' : ''}` }
             tabIndex={ 0 }
             type='text'
             value={ filterString }

--- a/frontend/css/_DropdownFilter.scss
+++ b/frontend/css/_DropdownFilter.scss
@@ -24,6 +24,10 @@
     &.expanded {
       border-radius: 7px 7px 0 0;
     }
+
+    &.disabled {
+      background-color: #d3d3d3;
+    }
   }
 
   &__inputElement {
@@ -59,15 +63,35 @@
     &:focus {
       outline: none;
     }
+
+    &.disabled {
+      background-color: #d3d3d3;
+      pointer-events: none;
+    }
   }
 
   &__icon {
     position: absolute;
     top: 12px;
     right: 12px;
+    transition-duration: 0.5s;
+    transition-property: transform;
+    transform: rotate(0deg);
 
     &:hover {
       cursor: pointer;
+    }
+
+    &.rotated {
+      transition-duration: 0.5s;
+      transition-property: transform;
+      transform: rotate(180deg);
+    }
+
+    &.disabled {
+      &:hover {
+        cursor: default;
+      }
     }
   }
 
@@ -86,6 +110,19 @@
     max-height: 180px;
     border-radius: 0 0 7px 7px;
     width: 100%;
+  }
+
+  &__noResults {
+    display: flex;
+    padding-left: 10px;
+    justify-content: flex-start;
+    height: 55px;
+    background: #fff;
+    border: 1px solid #f5f5f5;
+    box-sizing: border-box;
+    border-radius: 0;
+    text-align: center;
+    align-items: center;
   }
 
   &__element {

--- a/frontend/css/_DropdownFilter.scss
+++ b/frontend/css/_DropdownFilter.scss
@@ -72,7 +72,6 @@
 
   &__icon {
     position: absolute;
-    //top: 12px;
     top: 14px;
     right: 12px;
     transition-duration: 0.5s;
@@ -85,7 +84,7 @@
     }
 
     &.expanded {
-      top: 17px;
+      top: 16px;
       transition-duration: 0.5s;
       transition-property: transform;
       transform: rotate(180deg);

--- a/frontend/css/_DropdownFilter.scss
+++ b/frontend/css/_DropdownFilter.scss
@@ -72,20 +72,24 @@
 
   &__icon {
     position: absolute;
-    top: 12px;
+    //top: 12px;
+    top: 14px;
     right: 12px;
-    transition-duration: 0s;
+    transition-duration: 0.5s;
     transition-property: transform;
     transform: rotate(0deg);
+    transform-origin: top center;
 
     &:hover {
       cursor: pointer;
     }
 
     &.expanded {
-      transition-duration: 0s;
+      top: 17px;
+      transition-duration: 0.5s;
       transition-property: transform;
       transform: rotate(180deg);
+      transform-origin: top center;
     }
 
     &.disabled {

--- a/frontend/css/_DropdownFilter.scss
+++ b/frontend/css/_DropdownFilter.scss
@@ -74,7 +74,7 @@
     position: absolute;
     top: 12px;
     right: 12px;
-    transition-duration: 0.5s;
+    transition-duration: 0s;
     transition-property: transform;
     transform: rotate(0deg);
 
@@ -82,8 +82,8 @@
       cursor: pointer;
     }
 
-    &.rotated {
-      transition-duration: 0.5s;
+    &.expanded {
+      transition-duration: 0s;
       transition-property: transform;
       transform: rotate(180deg);
     }

--- a/frontend/css/_DropdownFilter.scss
+++ b/frontend/css/_DropdownFilter.scss
@@ -112,7 +112,7 @@
     width: 100%;
   }
 
-  &__noResults {
+  &--noResults {
     display: flex;
     padding-left: 10px;
     justify-content: flex-start;


### PR DESCRIPTION
Improved dropdown functionality by adding the following features:

- The dropdown stays expanded when a user selects a filter or clicks on the search box to manually search for a filter
- The dropdown stays expanded as users are deselecting filters
- The search box clears the text after the user selects a filter from the dropdown to prepare for a new search
- The dropdown displays a message saying "No results found." if the search does not match any applicable filters, or if there are no more filters to choose from
- The arrow/triangle on the right points in different directions depending on whether the dropdown is expanded or not
- The dropdown will appear disabled if there are no pre-selected filters and there are no filters available to choose from (visually, the dropdown will be grayed out, no special cursors will appear when hovering over different sections of the dropdown, the placeholder text will read "No filters apply", and the dropdown will be unable to expand)