### PR TITLE
Change GitHub Action version to 12.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: install node v14
+    - name: install node v12.16
       uses: actions/setup-node@v1
       with:
-        node-version: 14
+        node-version: '12.16'
     - run: yarn install
     - run: yarn test
   seqtest:
@@ -35,9 +35,9 @@ jobs:
         options: --health-cmd "curl localhost:9200/_cluster/health" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
     - uses: actions/checkout@v1
-    - name: install node v14
+    - name: install node v12.16
       uses: actions/setup-node@v1
       with:
-        node-version: 14
+        node-version: '12.16'
     - run: yarn install
     - run: yarn dbtest


### PR DESCRIPTION
Node versions 12.19 and 14 are failing (albeit for different reasons). Hard coding to 12.16 for now.