### PR TITLE
Apostrophe encoding bugfix

### DIFF
--- a/frontend/components/classModels/Section.ts
+++ b/frontend/components/classModels/Section.ts
@@ -122,7 +122,7 @@ class Section {
 
   // Unique list of all professors in all meetings, sorted alphabetically
   getProfs() : string[] {
-    return this.profs.length > 0 ? Array.from(this.profs).sort() : ['TBA'];
+    return this.profs.length > 0 ? Array.from(this.profs.map((prof) => _.unescape(prof))).sort() : ['TBA'];
   }
 
   getLocations(ignoreExams = true) : string[] {

--- a/frontend/components/classModels/Section.ts
+++ b/frontend/components/classModels/Section.ts
@@ -120,9 +120,9 @@ class Section {
     });
   }
 
-  // Unique list of all professors in all meetings, sorted alphabetically
+  // Unique list of all professors in all meetings, sorted alphabetically, unescape html entity decoding
   getProfs() : string[] {
-    return this.profs.length > 0 ? Array.from(this.profs.map((prof) => _.unescape(prof))).sort() : ['TBA'];
+    return this.profs.length > 0 ? Array.from(this.profs.map((prof) => unescape(prof))).sort() : ['TBA'];
   }
 
   getLocations(ignoreExams = true) : string[] {


### PR DESCRIPTION
- all special characters in professor names were rendered in HTML entity number (e.g., `'` is rendered as `&#39;`.
- used `unescape` from underscore.js to fix the bug.